### PR TITLE
Add Issue and PR Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev_issue.md
+++ b/.github/ISSUE_TEMPLATE/dev_issue.md
@@ -1,0 +1,28 @@
+---
+name: Developer issue
+about: Issue with description, learning objectives, todo, and useful links
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Description
+
+## Learning objectives
+
+- Objective
+
+## Todo
+
+These points are a rough guideline. **Please** feel free to discuss with others on the team about the best way to design this component!
+
+- Todo
+
+## Useful links
+
+- Useful link
+
+<!--
+Template sourced from https://github.com/hack4impact-uiuc/falling-fruit
+Shoutout to the wonderful FF team!
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
+Shoutout to the wonderful LAH team!
+-->
+
+## Status:
+
+<!--
+:rocket: Ready
+:construction: In development
+:no_entry_sign: Do not merge
+-->
+
+## Description
+
+<!--
+A few sentences describing the overall goals of the pull request's commits.
+-->
+
+Fixes #<number>
+
+## Todos
+
+<!--
+- [ ] Tests
+- [ ] Documentation
+-->
+
+## Screenshots
+
+<!--
+Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
+Mac OS GIFs: Try using Kap
+Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
+-->


### PR DESCRIPTION
# Pull Request

## Description

Add Hack4Impact's standard Issue and PR templates to this repo for our own development purposes. I'm not entirely sure how this will appear for developers given the existing templates in the OCF GitHub org, but I'm hoping it just adds them to the list.

## How Has This Been Tested?

Followed these guidelines: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
