### PR TITLE
Add Auth0 protection to home and form page

### DIFF
--- a/pages/api/get_token.ts
+++ b/pages/api/get_token.ts
@@ -1,0 +1,10 @@
+import { getAccessToken, withApiAuthRequired } from '@auth0/nextjs-auth0';
+
+export default withApiAuthRequired(async function token(req, res) {
+  try {
+    const accessToken = await getAccessToken(req, res);
+    res.status(200).json(accessToken);
+  } catch (error: any) {
+    res.status(error.status || 400).end(error.message);
+  }
+});

--- a/pages/form.tsx
+++ b/pages/form.tsx
@@ -1,3 +1,5 @@
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
+
 interface PanelFormDataBody {
   solarPanelDirection: number;
   solarPanelAngleTilt: number;
@@ -107,3 +109,5 @@ const Form = () => {
 };
 
 export default Form;
+
+export const getServerSideProps = withPageAuthRequired();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,7 @@
 import Head from 'next/head';
-import Link from 'next/link';
-import { useUser } from '@auth0/nextjs-auth0/client';
-import { useState } from 'react';
+import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 
 export default function Home(this: any) {
-  const { user } = useUser();
-
   return (
     <>
       <Head>
@@ -14,25 +10,8 @@ export default function Home(this: any) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main className="m-5">
-        {user ? (
-          <Link
-            className="bg-yellow-300 rounded-2xl p-2"
-            href="/api/auth/logout"
-            key="logout_button"
-          >
-            Logout
-          </Link>
-        ) : (
-          <Link
-            className="bg-yellow-300 rounded-2xl p-2"
-            href="/api/auth/login"
-            key="login_button"
-          >
-            Login
-          </Link>
-        )}
-      </main>
     </>
   );
 }
+
+export const getServerSideProps = withPageAuthRequired();


### PR DESCRIPTION
# Pull Request

## Description
* Wrapped home page and form page with withPageAuthRequired function
* Created a get_token endpoint
* Removed login/logout button as the user is automatically redirected to login

Fixes #19 

## How Has This Been Tested?
I checked that both the home page and form page redirected to login

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
