### PR TITLE
Change Input mode on location details page

### DIFF
--- a/pages/form/details.tsx
+++ b/pages/form/details.tsx
@@ -62,6 +62,8 @@ const Form = () => {
             step: 'any',
             required: true,
             onKeyDown: preventMinus,
+            pattern: '[0-9]*',
+            inputMode: 'numeric',
           }}
         />
 
@@ -81,6 +83,8 @@ const Form = () => {
             step: 'any',
             required: true,
             onKeyDown: preventMinus,
+            pattern: '[0-9]*',
+            inputMode: 'numeric',
           }}
         />
 
@@ -102,6 +106,8 @@ const Form = () => {
             min: '0',
             step: 'any',
             onKeyDown: preventMinus,
+            pattern: '[0-9]*',
+            inputMode: 'numeric',
           }}
         />
 


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready

<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Adds pattern and input mode props to input elements so that the numeric keyboard shows up on mobile. This makes it way easier to enter numbers on the location details page
<!--
A few sentences describing the overall goals of the pull request's commits.
-->


## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
