### PR TITLE
Redesign button loading indicator

### DIFF
--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 const Spinner: FC = () => (
   <svg
     aria-hidden="true"
-    className="w-8 h-8 mx-2 text-gray-200 animate-spin dark:text-ocf-gray-800 fill-ocf-yellow"
+    className="w-6 h-6 mx-4 text-gray-200 animate-spin dark:text-ocf-gray-300 fill-ocf-black"
     viewBox="0 0 100 101"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 const Spinner: FC = () => (
   <svg
     aria-hidden="true"
-    className="w-6 h-6 mx-4 text-gray-200 animate-spin dark:text-ocf-gray-300 fill-ocf-black"
+    className="w-5 h-5 mx-4 text-gray-200 animate-spin dark:text-ocf-gray-300 fill-ocf-black"
     viewBox="0 0 100 101"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/pages/form/details.tsx
+++ b/pages/form/details.tsx
@@ -125,7 +125,7 @@ const Form = () => {
         >
           {didSubmit && <Spinner />}
           Next
-          {didSubmit && <div className="w-6 mx-4" />}
+          {didSubmit && <div className="w-5 mx-4" />}
         </button>
         <Modal show={showModal} setShow={setShowModal} />
       </form>

--- a/pages/form/details.tsx
+++ b/pages/form/details.tsx
@@ -125,7 +125,7 @@ const Form = () => {
         >
           {didSubmit && <Spinner />}
           Next
-          {didSubmit && <div className="w-8 mx-2" />}
+          {didSubmit && <div className="w-6 mx-4" />}
         </button>
         <Modal show={showModal} setShow={setShowModal} />
       </form>


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: 🚀 

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

Redesign button loading indicator to match the [chakra-ui](https://chakra-ui.com/docs/components/button#button-loading-state) designs and [UX Movement designs](https://uxmovement.com/buttons/when-you-need-to-show-a-buttons-loading-state/).

- Change the indicator color to black
- Add more right margin to the spinning indicator icon
- Decrease the size of the spinning indicator icon

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

## Screenshots

<img width="322" alt="Screenshot 2023-03-14 at 12 32 05 PM" src="https://user-images.githubusercontent.com/21179174/225090292-110be534-e495-4545-a2a8-aa1af2b18124.png">

