### PR TITLE
Aggregate predictions over multiple sites

### DIFF
--- a/lib/hooks/useClickedOutside.ts
+++ b/lib/hooks/useClickedOutside.ts
@@ -1,5 +1,10 @@
 import { useEffect, RefObject } from 'react';
 
+/**
+ * Determines if the user clicked outside the ref
+ * @param ref reference to an HTML component
+ * @param handle function to call after a click outside the ref is detected
+ */
 const useClickedOutside = (ref: RefObject<any>, handler: () => void) => {
   useEffect(() => {
     /**

--- a/lib/hooks/useSiteAggregation.ts
+++ b/lib/hooks/useSiteAggregation.ts
@@ -18,16 +18,14 @@ const useSiteAggregation = (allSiteUUID: string[]) => {
     siteListFetcher
   );
 
-  const parsedAllSiteUUID = allSiteUUID
-    .reduce((prev, curr) => `${prev},${curr}`)
-    .substring(1);
-
   const {
     data: manyForecastData,
     error: manyForecastError,
     isLoading: isManyForecastLoading,
   } = useSWR(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/pv_forecast?site_uuids=${parsedAllSiteUUID}`,
+    `${
+      process.env.NEXT_PUBLIC_API_BASE_URL
+    }/api/pv_forecast?site_uuids=${allSiteUUID.join(',')}`,
     manyForecastDataFetcher
   );
 
@@ -41,8 +39,9 @@ const useSiteAggregation = (allSiteUUID: string[]) => {
           prevTotalSiteCapacity + newSite.installed_capacity_kw,
         0
       )
-    : 0;
-  let totalExpectedGeneration: ForecastDataPoint[] = [];
+    : undefined;
+
+  let totalExpectedGeneration: ForecastDataPoint[] | undefined = undefined;
 
   // Sum the expected generation for each date returned in all of the site forecasts
   if (manyForecastData) {

--- a/lib/hooks/useSiteAggregation.ts
+++ b/lib/hooks/useSiteAggregation.ts
@@ -2,6 +2,12 @@ import useSWR from 'swr';
 import { siteListFetcher, manyForecastDataFetcher } from './utils';
 import { ForecastDataPoint } from '../types';
 
+/**
+ * Sums the capacity and forecasts of multiple solar sites across
+ * all dates reported by the pv-sites API.
+ * @param allSiteUUID A list of UUIDs corresponding to multiple solar sites
+ * @return Aggregated predictions sorted by datetime
+ */
 const useSiteAggregation = (allSiteUUID: string[]) => {
   const {
     data: siteListData,

--- a/lib/hooks/useSiteAggregation.ts
+++ b/lib/hooks/useSiteAggregation.ts
@@ -1,0 +1,87 @@
+import useSWR from 'swr';
+import { siteListFetcher, manyForecastDataFetcher } from './utils';
+import { ForecastDataPoint } from '../types';
+
+const useSiteAggregation = (allSiteUUID: string[]) => {
+  const {
+    data: siteListData,
+    error: siteListError,
+    isLoading: isSiteListLoading,
+  } = useSWR(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/sites`,
+    siteListFetcher
+  );
+
+  const parsedAllSiteUUID = allSiteUUID
+    .reduce((prev, curr) => `${prev},${curr}`)
+    .substring(1);
+
+  const {
+    data: manyForecastData,
+    error: manyForecastError,
+    isLoading: isManyForecastLoading,
+  } = useSWR(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/pv_forecast?site_uuids=${parsedAllSiteUUID}`,
+    manyForecastDataFetcher
+  );
+
+  const error = AggregateError([manyForecastError, siteListError]);
+  const isLoading = isSiteListLoading || isManyForecastLoading;
+
+  // Sum the installed capacity at all of the sites
+  const totalInstalledCapacityKw = siteListData
+    ? siteListData.site_list.reduce(
+        (prevTotalSiteCapacity, newSite) =>
+          prevTotalSiteCapacity + newSite.installed_capacity_kw,
+        0
+      )
+    : 0;
+  let totalExpectedGeneration: ForecastDataPoint[] = [];
+
+  // Sum the expected generation for each date returned in all of the site forecasts
+  if (manyForecastData) {
+    const forecastMap = new Map<number, number>();
+
+    for (let siteIdx = 0; siteIdx < manyForecastData.length; siteIdx++) {
+      const siteForecastValues = manyForecastData[siteIdx].forecast_values;
+
+      for (
+        let forecastIdx = 0;
+        forecastIdx < siteForecastValues.length;
+        forecastIdx++
+      ) {
+        const { target_datetime_utc, expected_generation_kw } =
+          siteForecastValues[forecastIdx];
+
+        const currentAggregatedGeneration =
+          forecastMap.get(target_datetime_utc) ?? 0;
+
+        forecastMap.set(
+          target_datetime_utc,
+          currentAggregatedGeneration + expected_generation_kw
+        );
+      }
+    }
+
+    // Sort the aggregated forecasts based on datetime
+    totalExpectedGeneration = Array.from(
+      forecastMap,
+      ([target_datetime_utc, expected_generation_kw]) => ({
+        target_datetime_utc,
+        expected_generation_kw,
+      })
+    ).sort(
+      (forecastA, forecastB) =>
+        forecastA.target_datetime_utc - forecastB.target_datetime_utc
+    );
+  }
+
+  return {
+    totalInstalledCapacityKw,
+    totalExpectedGeneration,
+    error,
+    isLoading,
+  };
+};
+
+export default useSiteAggregation;

--- a/lib/hooks/useSiteData.ts
+++ b/lib/hooks/useSiteData.ts
@@ -2,6 +2,11 @@ import useSWR from 'swr';
 import { Site } from '../types';
 import { siteListFetcher, forecastFetcher } from './utils';
 
+/**
+ * Gets forecasted and solar panel data for a single site
+ * @param siteUUID UUID corresponding to a single site
+ * @returns forecasted and site data
+ */
 const useSiteData = (siteUUID: string) => {
   const {
     data: forecastData,

--- a/lib/hooks/useSiteData.ts
+++ b/lib/hooks/useSiteData.ts
@@ -1,46 +1,6 @@
-// const siteUUID = 'b97f68cd-50e0-49bb-a850-108d4a9f7b7e';
 import useSWR from 'swr';
-import { Fetcher } from 'swr';
-import { Site, SiteListProps, ForecastData } from '../types';
-
-interface UnparsedForecastData {
-  forecast_uuid: string;
-  site_uuid: string;
-  forecast_creation_datetime: string | number;
-  forecast_version: string;
-  forecast_values: UnparsedForecastDataPoint[];
-}
-
-interface UnparsedForecastDataPoint {
-  target_datetime_utc: string | number;
-  expected_generation_kw: number;
-}
-
-const forecastFetcher: Fetcher<ForecastData> = async (url: string) => {
-  const tempData: UnparsedForecastData = await fetch(url).then((res) =>
-    res.json()
-  );
-
-  if (typeof tempData.forecast_creation_datetime === 'string') {
-    tempData.forecast_creation_datetime = Date.parse(
-      tempData.forecast_creation_datetime
-    );
-  } else {
-    throw new Error('Data contains values with incompatible types');
-  }
-
-  tempData.forecast_values.map(({ target_datetime_utc }) => {
-    if (typeof target_datetime_utc === 'string') {
-      target_datetime_utc = Date.parse(target_datetime_utc);
-    } else {
-      throw new Error('Data contains values with incompatible types');
-    }
-  });
-  return tempData as ForecastData;
-};
-
-const siteListFetcher: Fetcher<SiteListProps> = async (url: string) =>
-  fetch(url).then((res) => res.json());
+import { Site } from '../types';
+import { siteListFetcher, forecastFetcher } from './utils';
 
 const useSiteData = (siteUUID: string) => {
   const {

--- a/lib/hooks/utils.ts
+++ b/lib/hooks/utils.ts
@@ -1,0 +1,59 @@
+import { url } from 'inspector';
+import { SiteList, ForecastData, UnparsedForecastData } from '../types';
+import { Fetcher } from 'swr';
+
+export const siteListFetcher: Fetcher<SiteList> = async (url: string) =>
+  fetch(url).then((res) => res.json());
+
+export const forecastFetcher: Fetcher<ForecastData> = async (url: string) => {
+  const tempData: UnparsedForecastData = await fetch(url).then((res) =>
+    res.json()
+  );
+
+  if (typeof tempData.forecast_creation_datetime === 'string') {
+    tempData.forecast_creation_datetime = Date.parse(
+      tempData.forecast_creation_datetime
+    );
+  } else {
+    throw new Error('Data contains values with incompatible types');
+  }
+
+  tempData.forecast_values.map(({ target_datetime_utc }) => {
+    if (typeof target_datetime_utc === 'string') {
+      target_datetime_utc = Date.parse(target_datetime_utc);
+    } else {
+      throw new Error('Data contains values with incompatible types');
+    }
+  });
+  return tempData as ForecastData;
+};
+
+export const manyForecastDataFetcher: Fetcher<Array<ForecastData>> = async (
+  url: string
+) => {
+  const allUnparsedForecasts: Array<UnparsedForecastData> = await fetch(
+    url
+  ).then((res) => res.json());
+
+  for (let idx = 0; idx < allUnparsedForecasts.length; idx++) {
+    if (
+      typeof allUnparsedForecasts[idx].forecast_creation_datetime === 'string'
+    ) {
+      allUnparsedForecasts[idx].forecast_creation_datetime = Date.parse(
+        allUnparsedForecasts[idx].forecast_creation_datetime as string
+      );
+    } else {
+      throw new Error('Data contains values with incompatible types');
+    }
+
+    allUnparsedForecasts[idx].forecast_values.map(({ target_datetime_utc }) => {
+      if (typeof target_datetime_utc === 'string') {
+        target_datetime_utc = Date.parse(target_datetime_utc);
+      } else {
+        throw new Error('Data contains values with incompatible types');
+      }
+    });
+  }
+
+  return allUnparsedForecasts as Array<ForecastData>;
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,7 +15,7 @@ export interface Site {
   updated_utc: string;
 }
 
-export interface SiteListProps {
+export interface SiteList {
   site_list: Site[];
 }
 
@@ -30,4 +30,16 @@ export interface ForecastData {
   forecast_creation_datetime: number;
   forecast_version: string;
   forecast_values: ForecastDataPoint[];
+}
+export interface UnparsedForecastData {
+  forecast_uuid: string;
+  site_uuid: string;
+  forecast_creation_datetime: string | number;
+  forecast_version: string;
+  forecast_values: UnparsedForecastDataPoint[];
+}
+
+export interface UnparsedForecastDataPoint {
+  target_datetime_utc: string | number;
+  expected_generation_kw: number;
 }


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: 🚀 

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

Create the `useSiteAggregation()` hook to aggregate predictions over multiple sites, including total solar energy generated at specific date-times and the sum of solar panel capacity across all sites.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #89 

## Todos

- [x] Create hook that aggregates PV forecasts and capacities over all sites
- [x] Test the hook
- [x] Add any additional necessary aggregations to the hook