### PR TITLE
Refactor Site page and SiteList Component to display SiteCards based on api data

### DIFF
--- a/components/SiteCard.tsx
+++ b/components/SiteCard.tsx
@@ -35,11 +35,13 @@ const SiteCard: FC<SiteCardProps> = ({ href, siteUUID }) => {
               Max. capacity: {installed_capacity_kw} kW
             </p>
           )}
-          {installed_capacity_kw && (
-            <p className="text-ocf-gray-500 font-medium text-xs">
-              Current yield: {currentOutput / installed_capacity_kw}%
-            </p>
-          )}
+          <p className="text-ocf-gray-500 font-medium text-xs">
+            Current yield:{' '}
+            {installed_capacity_kw
+              ? currentOutput / installed_capacity_kw
+              : currentOutput}
+            %
+          </p>
         </div>
       </div>
       {!href && (

--- a/components/SiteCard.tsx
+++ b/components/SiteCard.tsx
@@ -17,7 +17,7 @@ const SiteCard: FC<SiteCardProps> = ({ href, siteUUID }) => {
 
   const currentOutput = forecastData
     ? getCurrentTimeForecast(forecastData.forecast_values)
-    : 0;
+    : undefined;
 
   return (
     <a
@@ -28,7 +28,9 @@ const SiteCard: FC<SiteCardProps> = ({ href, siteUUID }) => {
         <h2 className="text-amber text-xl font-semibold">{client_site_name}</h2>
         <div className="flex flex-col mt-2 gap-1">
           <p className="text-ocf-gray-500 text-xs font-medium">
-            Current output: {currentOutput} kW
+            {`Current output: ${
+              currentOutput != undefined ? currentOutput + ' kW' : 'loading...'
+            }`}
           </p>
           {installed_capacity_kw && (
             <p className="text-ocf-gray-500 font-medium text-xs">
@@ -36,11 +38,12 @@ const SiteCard: FC<SiteCardProps> = ({ href, siteUUID }) => {
             </p>
           )}
           <p className="text-ocf-gray-500 font-medium text-xs">
-            Current yield:{' '}
-            {installed_capacity_kw
-              ? currentOutput / installed_capacity_kw
-              : currentOutput}
-            %
+            {`Current yield:
+            ${
+              installed_capacity_kw && currentOutput != undefined
+                ? currentOutput / installed_capacity_kw + '%'
+                : 'loading...'
+            }`}
           </p>
         </div>
       </div>

--- a/components/SiteCard.tsx
+++ b/components/SiteCard.tsx
@@ -1,53 +1,72 @@
 import { FC, PropsWithChildren } from 'react';
 import { DeleteIcon, EditIcon } from './icons';
 import Link from 'next/link';
+import { useSiteData } from '~/lib/hooks';
+import { getCurrentTimeForecast } from '~/lib/utils';
 
 interface SiteCardProps {
   href?: string;
+  siteUUID: string;
 }
 
-const SiteCard: FC<SiteCardProps> = ({ href }) => (
-  <a
-    href={href}
-    className="h-fit w-full max-w-lg flex bg-ocf-gray-1000 p-3 rounded-lg font-bold"
-  >
-    <div className="flex flex-col flex-1">
-      <h2 className="text-amber text-xl font-semibold">My Home</h2>
-      <div className="flex flex-col mt-2 gap-1">
-        <p className="text-ocf-gray-500 text-xs font-medium">
-          Panel direction: 135
-        </p>
-        <p className="text-ocf-gray-500 font-medium text-xs">Panel tilt: 40</p>
-        <p className="text-ocf-gray-500 font-medium text-xs">
-          Max. capacity: 2800 kWh
-        </p>
+const SiteCard: FC<SiteCardProps> = ({ href, siteUUID }) => {
+  const { forecastData, client_site_name, installed_capacity_kw } =
+    useSiteData(siteUUID);
+
+  const currentOutput = forecastData
+    ? getCurrentTimeForecast(forecastData.forecast_values)
+    : 0;
+
+  return (
+    <a
+      href={href}
+      className="h-fit w-full max-w-lg flex bg-ocf-gray-1000 p-3 rounded-lg font-bold"
+    >
+      <div className="flex flex-col flex-1">
+        <h2 className="text-amber text-xl font-semibold">{client_site_name}</h2>
+        <div className="flex flex-col mt-2 gap-1">
+          <p className="text-ocf-gray-500 text-xs font-medium">
+            Current output: {currentOutput} kW
+          </p>
+          {installed_capacity_kw && (
+            <p className="text-ocf-gray-500 font-medium text-xs">
+              Max. capacity: {installed_capacity_kw} kW
+            </p>
+          )}
+          {installed_capacity_kw && (
+            <p className="text-ocf-gray-500 font-medium text-xs">
+              Current yield: {currentOutput / installed_capacity_kw}%
+            </p>
+          )}
+        </div>
       </div>
-    </div>
-    {!href && (
-      <div className="flex flex-col w-fit">
-        <div className="flex-1">
+      {!href && (
+        <div className="flex flex-col w-fit">
+          <div className="flex-1">
+            <button>
+              <EditIcon />
+            </button>
+          </div>
           <button>
-            <EditIcon />
+            <DeleteIcon />
           </button>
         </div>
-        <button>
-          <DeleteIcon />
-        </button>
-      </div>
-    )}
-  </a>
-);
+      )}
+    </a>
+  );
+};
 
 interface SiteCardLinkProps {
   isEditMode: boolean;
+  siteUUID: string;
 }
 
-const SiteCardLink: FC<SiteCardLinkProps> = ({ isEditMode }) => {
+const SiteCardLink: FC<SiteCardLinkProps> = ({ isEditMode, siteUUID }) => {
   return isEditMode ? (
-    <SiteCard />
+    <SiteCard siteUUID={siteUUID} />
   ) : (
     <Link href="/dashboard" passHref>
-      <SiteCard />
+      <SiteCard siteUUID={siteUUID} />
     </Link>
   );
 };

--- a/data/site-list.json
+++ b/data/site-list.json
@@ -15,6 +15,54 @@
       "installed_capacity_kw": 1,
       "created_utc": "2023-02-16T01:14:29.397421+00:00",
       "updated_utc": "2023-02-16T01:14:29.397436+00:00"
+    },
+    {
+      "site_uuid": "b97f68cd-50e0-49bb-a850-108d4a9f7b7e",
+      "client_name": "client_name_1",
+      "client_site_id": "the site id used by the user",
+      "client_site_name": "the site name",
+      "region": "the site's region",
+      "dno": "the site's dno",
+      "gsp": "the site's gsp",
+      "orientation": null,
+      "tilt": null,
+      "latitude": 50.0,
+      "longitude": 0.0,
+      "installed_capacity_kw": 1,
+      "created_utc": "2023-02-16T01:14:29.397421+00:00",
+      "updated_utc": "2023-02-16T01:14:29.397436+00:00"
+    },
+    {
+      "site_uuid": "b97f68cd-50e0-49bb-a850-108d4a9f7b7e",
+      "client_name": "client_name_1",
+      "client_site_id": "the site id used by the user",
+      "client_site_name": "the site name",
+      "region": "the site's region",
+      "dno": "the site's dno",
+      "gsp": "the site's gsp",
+      "orientation": null,
+      "tilt": null,
+      "latitude": 50.0,
+      "longitude": 0.0,
+      "installed_capacity_kw": 1,
+      "created_utc": "2023-02-16T01:14:29.397421+00:00",
+      "updated_utc": "2023-02-16T01:14:29.397436+00:00"
+    },
+    {
+      "site_uuid": "b97f68cd-50e0-49bb-a850-108d4a9f7b7e",
+      "client_name": "client_name_1",
+      "client_site_id": "the site id used by the user",
+      "client_site_name": "the site name",
+      "region": "the site's region",
+      "dno": "the site's dno",
+      "gsp": "the site's gsp",
+      "orientation": null,
+      "tilt": null,
+      "latitude": 50.0,
+      "longitude": 0.0,
+      "installed_capacity_kw": 1,
+      "created_utc": "2023-02-16T01:14:29.397421+00:00",
+      "updated_utc": "2023-02-16T01:14:29.397436+00:00"
     }
   ]
 }

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -3,9 +3,15 @@ import { EditIcon } from '~/components/icons';
 import { useState } from 'react';
 import SiteCardLink from '~/components/SiteCard';
 import { withSites } from '~/lib/utils';
+import { forecastFetcher } from '~/lib/hooks/utils';
+import useSWR from 'swr';
 
 const Sites = () => {
   const [editMode, setEditMode] = useState(false);
+
+  const { data, error, isLoading } = useSWR(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/sites`
+  );
 
   return (
     <div className="h-full w-full flex flex-col gap-3 items-center px-5">

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -5,13 +5,18 @@ import SiteCardLink from '~/components/SiteCard';
 import { withSites } from '~/lib/utils';
 import { forecastFetcher } from '~/lib/hooks/utils';
 import useSWR from 'swr';
+import { mock } from 'node:test';
 
 const Sites = () => {
   const [editMode, setEditMode] = useState(false);
 
+  // this is to retrieve our list of mock UUIDs
   const { data, error, isLoading } = useSWR(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/sites`
   );
+
+  const mockUUID = data.site_list[0].site_uuid;
+  const siteUUIDs = [mockUUID, mockUUID, mockUUID, mockUUID];
 
   return (
     <div className="h-full w-full flex flex-col gap-3 items-center px-5">
@@ -25,10 +30,9 @@ const Sites = () => {
           )}
         </button>
       </div>
-      <SiteCardLink isEditMode={editMode} />
-      <SiteCardLink isEditMode={editMode} />
-      <SiteCardLink isEditMode={editMode} />
-      <SiteCardLink isEditMode={editMode} />
+      {siteUUIDs.map((site_uuid, idx) => (
+        <SiteCardLink key={idx} siteUUID={site_uuid} isEditMode={editMode} />
+      ))}
     </div>
   );
 };

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -43,7 +43,11 @@ const Sites = () => {
         </button>
       </div>
       {siteUUIDs.map((site_uuid: string, idx: number) => (
-        <SiteCardLink key={idx} siteUUID={site_uuid} isEditMode={editMode} />
+        <SiteCardLink
+          key={site_uuid}
+          siteUUID={site_uuid}
+          isEditMode={editMode}
+        />
       ))}
     </div>
   );

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -6,15 +6,21 @@ import { withSites } from '~/lib/utils';
 import { SiteList } from '~/lib/types';
 import useSWR from 'swr';
 
-const ParseSiteUUIDs = (data: SiteList): string[] => {
-  const res = [];
+/**
+ * Helper function that returns a string[] of all the UUIDs collected from our data
+ * @param data the raw list of all site objects (contains more than just uuid)
+ * @returns siteUUIDs, a string array of all the valid site UUIDs
+ */
+const parseSiteUUIDs = (data: SiteList): string[] => {
+  const siteUUIDs = [];
   if (data) {
     for (let i = 0; i < data.site_list.length; i++) {
-      res.push(data.site_list[i].site_uuid);
+      siteUUIDs.push(data.site_list[i].site_uuid);
     }
   }
-  return res;
+  return siteUUIDs;
 };
+
 const Sites = () => {
   const [editMode, setEditMode] = useState(false);
 
@@ -22,7 +28,7 @@ const Sites = () => {
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/sites`
   );
 
-  const siteUUIDs: string[] = ParseSiteUUIDs(data);
+  const siteUUIDs: string[] = parseSiteUUIDs(data);
 
   return (
     <div className="h-full w-full flex flex-col gap-3 items-center px-5">

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -42,10 +42,10 @@ const Sites = () => {
           )}
         </button>
       </div>
-      {siteUUIDs.map((site_uuid: string, idx: number) => (
+      {siteUUIDs.map((siteUUID: string) => (
         <SiteCardLink
-          key={site_uuid}
-          siteUUID={site_uuid}
+          key={siteUUID}
+          siteUUID={siteUUID}
           isEditMode={editMode}
         />
       ))}

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -3,20 +3,26 @@ import { EditIcon } from '~/components/icons';
 import { useState } from 'react';
 import SiteCardLink from '~/components/SiteCard';
 import { withSites } from '~/lib/utils';
-import { forecastFetcher } from '~/lib/hooks/utils';
+import { SiteList } from '~/lib/types';
 import useSWR from 'swr';
-import { mock } from 'node:test';
 
+const ParseSiteUUIDs = (data: SiteList): string[] => {
+  const res = [];
+  if (data) {
+    for (let i = 0; i < data.site_list.length; i++) {
+      res.push(data.site_list[i].site_uuid);
+    }
+  }
+  return res;
+};
 const Sites = () => {
   const [editMode, setEditMode] = useState(false);
 
-  // this is to retrieve our list of mock UUIDs
   const { data, error, isLoading } = useSWR(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/sites`
   );
 
-  const mockUUID = data.site_list[0].site_uuid;
-  const siteUUIDs = [mockUUID, mockUUID, mockUUID, mockUUID];
+  const siteUUIDs: string[] = ParseSiteUUIDs(data);
 
   return (
     <div className="h-full w-full flex flex-col gap-3 items-center px-5">
@@ -30,7 +36,7 @@ const Sites = () => {
           )}
         </button>
       </div>
-      {siteUUIDs.map((site_uuid, idx) => (
+      {siteUUIDs.map((site_uuid: string, idx: number) => (
         <SiteCardLink key={idx} siteUUID={site_uuid} isEditMode={editMode} />
       ))}
     </div>


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: :rocket:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
For this pull request, the main goal was to refactor the code to render the site card based on the list of UUIDs. The first portion of the code, I defined a method `ParseSiteUUIDs(data)` that takes in the list of siteUUIDs from the mock api call and converts it into a string array of exclusive the siteUUIDs. Then, that information is passed into a SiteCardLink component (which I changed the props for) to retrieve and display the correct data. I also added 3 more siteUUIDs (which are just duplicates of the first) to the site_uuids file. 

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #120 

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
