### PR TITLE
Fix timezones and some fetching

### DIFF
--- a/components/SiteCard.tsx
+++ b/components/SiteCard.tsx
@@ -25,7 +25,9 @@ const SiteCard: FC<SiteCardProps> = ({ href, siteUUID }) => {
       className="h-fit w-full max-w-lg flex bg-ocf-black-500 p-3 rounded-lg font-bold"
     >
       <div className="flex flex-col flex-1">
-        <h2 className="text-amber text-xl font-semibold">{client_site_name}</h2>
+        <h2 className="text-amber text-xl font-semibold">
+          {client_site_name ?? 'Loading...'}
+        </h2>
         <div className="flex flex-col mt-2 gap-1">
           <p className="text-ocf-gray-500 text-xs font-medium">
             {`Current output: ${

--- a/components/SiteCard.tsx
+++ b/components/SiteCard.tsx
@@ -12,7 +12,7 @@ interface SiteCardProps {
 }
 
 const SiteCard: FC<SiteCardProps> = ({ href, siteUUID }) => {
-  const { forecastData, client_site_name, installed_capacity_kw } =
+  const { forecastData, client_site_name, installed_capacity_kw, isLoading } =
     useSiteData(siteUUID);
 
   const currentOutput = forecastData
@@ -26,7 +26,7 @@ const SiteCard: FC<SiteCardProps> = ({ href, siteUUID }) => {
     >
       <div className="flex flex-col flex-1">
         <h2 className="text-amber text-xl font-semibold">
-          {client_site_name ?? 'Loading...'}
+          {isLoading ? 'Loading...' : client_site_name ?? 'My Site'}
         </h2>
         <div className="flex flex-col mt-2 gap-1">
           <p className="text-ocf-gray-500 text-xs font-medium">

--- a/components/graphs/Graph.tsx
+++ b/components/graphs/Graph.tsx
@@ -12,6 +12,7 @@ import { formatter, forecastDataOverDateRange } from 'lib/graphs';
 import { useSiteData } from 'lib/hooks';
 import useTime from '~/lib/hooks/useTime';
 import { FC } from 'react';
+import { ForecastDataPoint } from '~/lib/types';
 
 const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const { forecastData, latitude, longitude } = useSiteData(siteUUID);
@@ -19,13 +20,13 @@ const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
 
   const endDate = new Date();
   endDate.setHours(endDate.getHours() + 48);
-  const graphData = forecastData
-    ? forecastDataOverDateRange(
-        forecastData.forecast_values,
-        new Date(currentTime),
-        endDate
-      )
-    : [];
+  const graphData =
+    forecastData &&
+    forecastDataOverDateRange(
+      forecastData.forecast_values,
+      new Date(currentTime),
+      endDate
+    );
   const maxGeneration = graphData
     ? Math.max(...graphData.map((value) => value.expected_generation_kw))
     : 0;
@@ -62,8 +63,8 @@ const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
             dataKey="target_datetime_utc"
             stroke="white"
             axisLine={false}
-            tickFormatter={(point: string) =>
-              formatter.format(Date.parse(point))
+            tickFormatter={(point: ForecastDataPoint['target_datetime_utc']) =>
+              formatter.format(new Date(point))
             }
           />
           <YAxis
@@ -74,18 +75,20 @@ const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
             fontSize="10px"
             axisLine={false}
             stroke="white"
-            tickFormatter={(val: number) => val.toFixed(2)}
+            tickFormatter={(val: ForecastDataPoint['expected_generation_kw']) =>
+              val.toFixed(2)
+            }
           />
           <Tooltip
             wrapperStyle={{ outline: 'none' }}
             contentStyle={{ backgroundColor: '#2B2B2B90', opacity: 1 }}
             labelStyle={{ color: 'white' }}
-            formatter={(value: number, name, props) => [
+            formatter={(value: ForecastDataPoint['expected_generation_kw']) => [
               parseFloat(value.toFixed(5)),
               'kW',
             ]}
-            labelFormatter={(point: string) =>
-              formatter.format(Date.parse(point))
+            labelFormatter={(point: ForecastDataPoint['target_datetime_utc']) =>
+              formatter.format(new Date(point))
             }
           />
           <Line

--- a/lib/graphs.ts
+++ b/lib/graphs.ts
@@ -1,5 +1,3 @@
-import useSWR, { Fetcher } from 'swr';
-
 /**
  * Converts Date object into Hour-Minute format based on device region
  */
@@ -12,50 +10,6 @@ interface ForecastDataPoint {
   target_datetime_utc: number;
   expected_generation_kw: number;
 }
-
-interface ForecastData {
-  forecast_uuid: string;
-  site_uuid: string;
-  forecast_creation_datetime: number;
-  forecast_version: string;
-  forecast_values: ForecastDataPoint[];
-}
-
-interface UnparsedForecastDataPoint {
-  target_datetime_utc: string | number;
-  expected_generation_kw: number;
-}
-
-interface UnparsedForecastData {
-  forecast_uuid: string;
-  site_uuid: string;
-  forecast_creation_datetime: string | number;
-  forecast_version: string;
-  forecast_values: UnparsedForecastDataPoint[];
-}
-
-const forecastFetcher: Fetcher<ForecastData> = async (url: string) => {
-  const tempData: UnparsedForecastData = await fetch(url).then((res) =>
-    res.json()
-  );
-
-  if (typeof tempData.forecast_creation_datetime === 'string') {
-    tempData.forecast_creation_datetime = Date.parse(
-      tempData.forecast_creation_datetime
-    );
-  } else {
-    throw new Error('Data contains values with incompatible types');
-  }
-
-  tempData.forecast_values.map(({ target_datetime_utc }) => {
-    if (typeof target_datetime_utc === 'string') {
-      target_datetime_utc = Date.parse(target_datetime_utc);
-    } else {
-      throw new Error('Data contains values with incompatible types');
-    }
-  });
-  return tempData as ForecastData;
-};
 
 /**
  * @returns the index of the forecasted date that is closest to the target time

--- a/lib/hooks/useSiteAggregation.ts
+++ b/lib/hooks/useSiteAggregation.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 import { manyForecastDataFetcher } from './utils';
-import { ForecastDataPoint } from '../types';
+import { ForecastDataPoint, SiteList } from '../types';
 
 /**
  * Sums the capacity and forecasts of multiple solar sites across
@@ -13,7 +13,7 @@ const useSiteAggregation = (allSiteUUID: string[]) => {
     data: siteListData,
     error: siteListError,
     isLoading: isSiteListLoading,
-  } = useSWR(
+  } = useSWR<SiteList>(
     `${process.env.NEXT_PUBLIC_API_BASE_URL_GET}/sites`
   );
 

--- a/lib/hooks/useSiteAggregation.ts
+++ b/lib/hooks/useSiteAggregation.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { siteListFetcher, manyForecastDataFetcher } from './utils';
+import { manyForecastDataFetcher } from './utils';
 import { ForecastDataPoint } from '../types';
 
 /**
@@ -14,8 +14,7 @@ const useSiteAggregation = (allSiteUUID: string[]) => {
     error: siteListError,
     isLoading: isSiteListLoading,
   } = useSWR(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL_GET}/sites`,
-    siteListFetcher
+    `${process.env.NEXT_PUBLIC_API_BASE_URL_GET}/sites`
   );
 
   const {

--- a/lib/hooks/useSiteAggregation.ts
+++ b/lib/hooks/useSiteAggregation.ts
@@ -13,9 +13,7 @@ const useSiteAggregation = (allSiteUUID: string[]) => {
     data: siteListData,
     error: siteListError,
     isLoading: isSiteListLoading,
-  } = useSWR<SiteList>(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL_GET}/sites`
-  );
+  } = useSWR<SiteList>(`${process.env.NEXT_PUBLIC_API_BASE_URL_GET}/sites`);
 
   const {
     data: manyForecastData,

--- a/lib/hooks/useSiteData.ts
+++ b/lib/hooks/useSiteData.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
-import { Site } from '../types';
-import { siteListFetcher, forecastFetcher } from './utils';
+import { Site, SiteList } from '../types';
+import { forecastFetcher } from './utils';
 
 /**
  * Gets forecasted and solar panel data for a single site
@@ -21,10 +21,7 @@ const useSiteData = (siteUUID: string) => {
     data: siteListData,
     error: siteListError,
     isLoading: isSiteListLoading,
-  } = useSWR(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL_GET}/sites`,
-    siteListFetcher
-  );
+  } = useSWR<SiteList>(`${process.env.NEXT_PUBLIC_API_BASE_URL_GET}/sites`);
 
   const error = AggregateError([forecastError, siteListError]);
   const isLoading = isSiteListLoading || isForecastLoading;

--- a/lib/hooks/utils.ts
+++ b/lib/hooks/utils.ts
@@ -1,30 +1,50 @@
 import { Fetcher } from 'swr';
-import { ForecastData, SiteList, UnparsedForecastData } from '../types';
+import { ForecastData, UnparsedForecastData } from '../types';
 
-export const siteListFetcher: Fetcher<SiteList> = async (url: string) =>
-  fetch(url).then((res) => res.json());
+/**
+ * Parses a datetime string from the Nowcasting API, assumed to be in UTC.
+ * The datetime string may or may not include a timezone indicator.
+ * @param datetime The nowcasting datetime string
+ * @returns The datetime's UNIX timestamp
+ */
+function parseNowcastingDatetime(datetime: string) {
+  if (!datetime.endsWith('Z')) {
+    datetime += 'Z';
+  }
+  return Date.parse(datetime);
+}
+
+function parseForecastData(
+  unparsedForecastData: UnparsedForecastData
+): ForecastData {
+  const forecast_creation_datetime = parseNowcastingDatetime(
+    unparsedForecastData.forecast_creation_datetime
+  );
+
+  const forecast_values = unparsedForecastData.forecast_values.map(
+    (forecastValue) => {
+      return {
+        ...forecastValue,
+        target_datetime_utc: parseNowcastingDatetime(
+          forecastValue.target_datetime_utc
+        ),
+      };
+    }
+  );
+
+  return {
+    ...unparsedForecastData,
+    forecast_creation_datetime,
+    forecast_values,
+  };
+}
 
 export const forecastFetcher: Fetcher<ForecastData> = async (url: string) => {
   const tempData: UnparsedForecastData = await fetch(url).then((res) =>
     res.json()
   );
 
-  if (typeof tempData.forecast_creation_datetime === 'string') {
-    tempData.forecast_creation_datetime = Date.parse(
-      tempData.forecast_creation_datetime
-    );
-  } else {
-    throw new Error('Data contains values with incompatible types');
-  }
-
-  tempData.forecast_values.map(({ target_datetime_utc }) => {
-    if (typeof target_datetime_utc === 'string') {
-      target_datetime_utc = Date.parse(target_datetime_utc);
-    } else {
-      throw new Error('Data contains values with incompatible types');
-    }
-  });
-  return tempData as ForecastData;
+  return parseForecastData(tempData);
 };
 
 export const manyForecastDataFetcher: Fetcher<Array<ForecastData>> = async (
@@ -34,25 +54,7 @@ export const manyForecastDataFetcher: Fetcher<Array<ForecastData>> = async (
     url
   ).then((res) => res.json());
 
-  for (let idx = 0; idx < allUnparsedForecasts.length; idx++) {
-    if (
-      typeof allUnparsedForecasts[idx].forecast_creation_datetime === 'string'
-    ) {
-      allUnparsedForecasts[idx].forecast_creation_datetime = Date.parse(
-        allUnparsedForecasts[idx].forecast_creation_datetime as string
-      );
-    } else {
-      throw new Error('Data contains values with incompatible types');
-    }
-
-    allUnparsedForecasts[idx].forecast_values.map(({ target_datetime_utc }) => {
-      if (typeof target_datetime_utc === 'string') {
-        target_datetime_utc = Date.parse(target_datetime_utc);
-      } else {
-        throw new Error('Data contains values with incompatible types');
-      }
-    });
-  }
-
-  return allUnparsedForecasts as Array<ForecastData>;
+  return allUnparsedForecasts.map((unparsedForecast) =>
+    parseForecastData(unparsedForecast)
+  );
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,15 +31,16 @@ export interface ForecastData {
   forecast_version: string;
   forecast_values: ForecastDataPoint[];
 }
+
 export interface UnparsedForecastData {
   forecast_uuid: string;
   site_uuid: string;
-  forecast_creation_datetime: string | number;
+  forecast_creation_datetime: string;
   forecast_version: string;
   forecast_values: UnparsedForecastDataPoint[];
 }
 
 export interface UnparsedForecastDataPoint {
-  target_datetime_utc: string | number;
+  target_datetime_utc: string;
   expected_generation_kw: number;
 }

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -24,11 +24,14 @@ const parseSiteUUIDs = (data: SiteList): string[] => {
 const Sites = () => {
   const [editMode, setEditMode] = useState(false);
 
-  const { data, error, isLoading } = useSWR(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/sites`
+  const { data } = useSWR<SiteList>(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL_GET}/sites`
   );
 
-  const siteUUIDs: string[] = parseSiteUUIDs(data);
+  // TODO: Paginate this or something... when pulling from actual API it's just too many
+  const siteData = { site_list: data?.site_list.slice(0, 5) ?? [] };
+
+  const siteUUIDs = parseSiteUUIDs(siteData);
 
   return (
     <div className="h-full w-full flex flex-col gap-3 items-center px-5">


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fix some timezone issues. Before this, nowcasting forecast times were being parsed in the user's local timezone. Since the sites we're working with _are_ actually in UTC, this effectively made the graphs display the forecasts in the site timezone (that's funny). Parsing in the user's local timezone won't work for any site outside UTC though, so now I've changed the code to make sure we're parsing the times in UTC, which _correctly_ makes the graph show the forecasts in UTC. We can in the future change the graph's x-axis to show correct timezone using this: https://stackoverflow.com/a/62155199.


<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
