### PR TITLE
Attempt graph animation fix and add 'now indicator'

### DIFF
--- a/components/graphs/Graph.tsx
+++ b/components/graphs/Graph.tsx
@@ -34,7 +34,7 @@ const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     useSiteData(siteUUID);
   const [timeEnabled, setTimeEnabled] = useState(false);
   const { currentTime } = useTime(latitude, longitude, {
-    enabled: timeEnabled,
+    updateEnabled: timeEnabled,
   });
 
   const endDate = new Date();

--- a/components/graphs/Graph.tsx
+++ b/components/graphs/Graph.tsx
@@ -1,6 +1,13 @@
+import { LegendLineGraphIcon } from '@openclimatefix/nowcasting-ui.icons.icons';
+import {
+  forecastDataOverDateRange,
+  formatter,
+  getCurrentTimeForecastIndex,
+} from 'lib/graphs';
+import { useSiteData } from 'lib/hooks';
+import { FC, useState } from 'react';
 import {
   CartesianGrid,
-  Label,
   Line,
   LineChart,
   ReferenceLine,
@@ -9,17 +16,8 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import { LegendLineGraphIcon } from '@openclimatefix/nowcasting-ui.icons.icons';
-import {
-  formatter,
-  forecastDataOverDateRange,
-  getCurrentTimeForecastIndex,
-} from 'lib/graphs';
-import { useSiteData } from 'lib/hooks';
 import useTime from '~/lib/hooks/useTime';
-import { FC, useState } from 'react';
 import { ForecastDataPoint } from '~/lib/types';
-import { LineCircle } from '../icons/future_threshold';
 
 function getGraphStartDate(currentTime: number) {
   const currentDate = new Date(currentTime);
@@ -30,35 +28,6 @@ function getGraphStartDate(currentTime: number) {
     currentDate.getHours() - 5
   );
 }
-
-const CustomizedLabel: FC<any> = ({
-  value,
-  offset,
-  viewBox: { x },
-  className,
-  height,
-}) => {
-  const yy = height * 0.75 + 5;
-  return (
-    <g>
-      <g className="fill-white">
-        <text
-          x={x + 1}
-          y={yy + 15}
-          stroke="white"
-          strokeWidth="5em"
-          textAnchor="middle"
-        >
-          {/* Use invisible "H" character with stroke width to create white background around text */}
-          {'H'.repeat(value.length)}
-        </text>
-        <text x={x + 1} y={yy + 15} textAnchor="middle" className={className}>
-          {value}
-        </text>
-      </g>
-    </g>
-  );
-};
 
 const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const { forecastData, latitude, longitude, isLoading } =
@@ -88,6 +57,27 @@ const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     (3 * maxGeneration) / 4,
     maxGeneration,
   ];
+
+  const renderLabel = ({ viewBox: { x }, height }: any) => {
+    const yy = height * 0.75 + 5;
+    const textProps = {
+      className: 'text-xs fill-ocf-gray-1000',
+      textAnchor: 'middle',
+      x: x + 1,
+      y: yy + 10,
+    };
+    return (
+      <g>
+        <g className="fill-white">
+          <text stroke="white" strokeWidth="1em" {...textProps}>
+            {/* Use invisible "H" character with stroke width to create white background around text */}
+            {'H'.repeat('Now'.length)}
+          </text>
+          <text {...textProps}>Now</text>
+        </g>
+      </g>
+    );
+  };
 
   return (
     <div className="my-2 w-full h-[260px] bg-ocf-black-500 rounded-2xl">
@@ -156,15 +146,9 @@ const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
                       .target_datetime_utc
                   : 0
               }
-              strokeWidth={2}
+              strokeWidth={1}
               stroke="white"
-              label={
-                <CustomizedLabel
-                  value="Now"
-                  height={200}
-                  className="text-xs fill-ocf-gray-1000 uppercase font-semibold"
-                />
-              }
+              label={(props) => renderLabel({ ...props, height: 200 })}
             ></ReferenceLine>
           </LineChart>
         </ResponsiveContainer>

--- a/components/graphs/ThresholdGraph.tsx
+++ b/components/graphs/ThresholdGraph.tsx
@@ -36,7 +36,7 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     useSiteData(siteUUID);
   const [timeEnabled, setTimeEnabled] = useState(false);
   const { currentTime } = useTime(latitude, longitude, {
-    enabled: timeEnabled,
+    updateEnabled: timeEnabled,
   });
 
   const graphData =

--- a/components/graphs/ThresholdGraph.tsx
+++ b/components/graphs/ThresholdGraph.tsx
@@ -34,7 +34,10 @@ import useTime from '~/lib/hooks/useTime';
 const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const { forecastData, latitude, longitude, isLoading } =
     useSiteData(siteUUID);
-  const { currentTime } = useTime(latitude, longitude);
+  const [timeEnabled, setTimeEnabled] = useState(false);
+  const { currentTime } = useTime(latitude, longitude, {
+    enabled: timeEnabled,
+  });
 
   const graphData =
     forecastData &&
@@ -193,53 +196,53 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
         <div className="flex justify-end mt-[20px] mr-10 text-sm">
           <FutureThresholdLegendIcon />
         </div>
-        <ResponsiveContainer className="mt-[15px]" width="100%" height={100}>
-          <AreaChart
-            data={graphData}
-            margin={{
-              top: 0,
-              right: 40,
-              left: 0,
-              bottom: 10,
-            }}
-          >
-            <defs>{generateGraphGradient()}</defs>
-            <YAxis
-              type="number"
-              domain={[0, maxGeneration + 0.25]}
-              axisLine={false}
-              tick={false}
-            />
-            <Area
-              type="monotone"
-              dataKey="expected_generation_kw"
-              strokeWidth={2}
-              stroke="white"
-              strokeDasharray="2"
-              fill="url(#colorUv)"
-              // Necessary for label list https://stackoverflow.com/a/55724641
-              // Better solution for this would be nice
-              isAnimationActive={false}
+        {!isLoading && (
+          <ResponsiveContainer className="mt-[15px]" width="100%" height={100}>
+            <AreaChart
+              data={graphData}
+              margin={{
+                top: 0,
+                right: 40,
+                left: 0,
+                bottom: 10,
+              }}
             >
-              <LabelList
+              <defs>{generateGraphGradient()}</defs>
+              <YAxis
+                type="number"
+                domain={[0, maxGeneration + 0.25]}
+                axisLine={false}
+                tick={false}
+              />
+              <Area
+                type="monotone"
                 dataKey="expected_generation_kw"
-                content={renderCurrentTimeMarker}
-              />
-            </Area>
-            <ReferenceLine
-              y={graphThreshold}
-              strokeWidth={2}
-              stroke="#FFD053"
-              strokeDasharray="2"
-            >
-              <Label
-                value={graphThreshold + ' kW'}
-                position="left"
-                className="text-xs fill-ocf-yellow"
-              />
-            </ReferenceLine>
-          </AreaChart>
-        </ResponsiveContainer>
+                strokeWidth={2}
+                stroke="white"
+                strokeDasharray="2"
+                fill="url(#colorUv)"
+                onAnimationEnd={() => setTimeEnabled(true)}
+              >
+                <LabelList
+                  dataKey="expected_generation_kw"
+                  content={renderCurrentTimeMarker}
+                />
+              </Area>
+              <ReferenceLine
+                y={graphThreshold}
+                strokeWidth={2}
+                stroke="#FFD053"
+                strokeDasharray="2"
+              >
+                <Label
+                  value={graphThreshold + ' kW'}
+                  position="left"
+                  className="text-xs fill-ocf-yellow"
+                />
+              </ReferenceLine>
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
       </div>
       <div className="flex flex-col justify-center content-center absolute bottom-8 inset-x-0 text-center">
         {renderStartAndEndTime()}

--- a/lib/graphs.ts
+++ b/lib/graphs.ts
@@ -24,8 +24,7 @@ export const getClosestForecastIndex = (
       .map((forecast_values) => ({
         ...forecast_values,
         difference: Math.abs(
-          targetDate.getTime() -
-            new Date(forecast_values.target_datetime_utc).getTime()
+          targetDate.getTime() - forecast_values.target_datetime_utc
         ),
       }))
       .reduce((prev, curr) =>

--- a/lib/graphs.ts
+++ b/lib/graphs.ts
@@ -78,25 +78,7 @@ export const getGraphEndDate = (currentTime: number) => {
 export const getCurrentTimeForecastIndex = (
   forecast_values: ForecastDataPoint[]
 ) => {
-  if (forecast_values) {
-    const currentDate = new Date();
-
-    const closestDateIndex = forecast_values
-      .map((forecast_values, index) => ({ ...forecast_values, index: index }))
-      .map((forecast_values) => ({
-        ...forecast_values,
-        difference: Math.abs(
-          currentDate.getTime() -
-            new Date(forecast_values.target_datetime_utc).getTime()
-        ),
-      }))
-      .reduce((prev, curr) =>
-        prev.difference < curr.difference ? prev : curr
-      ).index;
-
-    return closestDateIndex;
-  }
-  return 0;
+  return getClosestForecastIndex(forecast_values, new Date());
 };
 
 /* Represents the threshold for the graph */

--- a/lib/hooks/useTime.ts
+++ b/lib/hooks/useTime.ts
@@ -1,8 +1,13 @@
 import { useEffect, useState } from 'react';
-import { formatter } from '../graphs';
-
 const SunCalc = require('suncalc');
 
+type UseTimeOptions = {
+  enabled: boolean;
+};
+
+const defaultUseTimeOptions = {
+  enabled: true,
+};
 /**
  * Creates a hook more accessesing specific values like the current time, whether it is daytime
  * @param latitude, the latitude float value that is passed in
@@ -13,7 +18,7 @@ const SunCalc = require('suncalc');
 const useTime = (
   latitude?: number,
   longitude?: number,
-  { enabled = false }: { enabled: boolean } = { enabled: false }
+  { enabled = false }: UseTimeOptions = defaultUseTimeOptions
 ) => {
   const [currentTime, setCurrentTime] = useState(Date.now());
 

--- a/lib/hooks/useTime.ts
+++ b/lib/hooks/useTime.ts
@@ -10,7 +10,11 @@ const SunCalc = require('suncalc');
  * @returns currentTimes, version of the current time (right now) that a user can format
  * @returns isDaytime, boolean value indicating whether it is daytime or not based on current time zone.
  */
-const useTime = (latitude?: number, longitude?: number) => {
+const useTime = (
+  latitude?: number,
+  longitude?: number,
+  { enabled = false }: { enabled: boolean } = { enabled: false }
+) => {
   const [currentTime, setCurrentTime] = useState(Date.now());
 
   // get sunrise/sunset time for passed in location
@@ -22,13 +26,15 @@ const useTime = (latitude?: number, longitude?: number) => {
   const sunsetTime = times ? times.sunset : null;
 
   useEffect(() => {
-    const intervalId = setInterval(() => {
-      setCurrentTime(Date.now());
-    }, 1000);
+    if (enabled) {
+      const intervalId = setInterval(() => {
+        setCurrentTime(Date.now());
+      }, 1000);
 
-    // clear interval on re-render to avoid memory leaks
-    return () => clearInterval(intervalId);
-  });
+      // clear interval on re-render to avoid memory leaks
+      return () => clearInterval(intervalId);
+    }
+  }, [enabled]);
 
   // default to daytime
   const isDaytime =

--- a/lib/hooks/useTime.ts
+++ b/lib/hooks/useTime.ts
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react';
 const SunCalc = require('suncalc');
 
 type UseTimeOptions = {
-  enabled: boolean;
+  updateEnabled: boolean;
 };
 
 const defaultUseTimeOptions = {
-  enabled: true,
+  updateEnabled: true,
 };
 /**
  * Creates a hook more accessesing specific values like the current time, whether it is daytime
@@ -18,7 +18,7 @@ const defaultUseTimeOptions = {
 const useTime = (
   latitude?: number,
   longitude?: number,
-  { enabled = false }: UseTimeOptions = defaultUseTimeOptions
+  { updateEnabled = false }: UseTimeOptions = defaultUseTimeOptions
 ) => {
   const [currentTime, setCurrentTime] = useState(Date.now());
 
@@ -31,7 +31,7 @@ const useTime = (
   const sunsetTime = times ? times.sunset : null;
 
   useEffect(() => {
-    if (enabled) {
+    if (updateEnabled) {
       const intervalId = setInterval(() => {
         setCurrentTime(Date.now());
       }, 1000);
@@ -39,7 +39,7 @@ const useTime = (
       // clear interval on re-render to avoid memory leaks
       return () => clearInterval(intervalId);
     }
-  }, [enabled]);
+  }, [updateEnabled]);
 
   // default to daytime
   const isDaytime =


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

🚀 Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fix animation by disabling `useTime` while graph data loads. Add now indicator to lower graph

Fixes: #153

## Screenshots

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/23221268/227816588-83d3d97d-7fd3-421e-89f4-a72d8112bce0.png">


<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
