### PR TITLE
Create a hook to format data based on the user's local time zone

### DIFF
--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import EnergyRecommendation from '~/components/dashboard-modules/EnergyRecommendation';
 import ThresholdGraph from '~/components/graphs/ThresholdGraph';
+import useDateFormatter from '~/lib/hooks/useDateFormatter';
 import { withSites } from '~/lib/utils';
 import CurrentCapacity from './dashboard-modules/CurrentCapacity';
 import CurrentOutput from './dashboard-modules/CurrentOutput';

--- a/components/graphs/Graph.tsx
+++ b/components/graphs/Graph.tsx
@@ -2,7 +2,6 @@ import { LegendLineGraphIcon } from '@openclimatefix/nowcasting-ui.icons.icons';
 import {
   forecastDataOverDateRange,
   getCurrentTimeForecastIndex,
-  weekdayFormatter,
 } from 'lib/graphs';
 import { useSiteData } from 'lib/hooks';
 import { FC, useState } from 'react';
@@ -16,6 +15,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import useDateFormatter from '~/lib/hooks/useDateFormatter';
 import useTime from '~/lib/hooks/useTime';
 import { ForecastDataPoint } from '~/lib/types';
 
@@ -36,7 +36,7 @@ const Graph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const { currentTime } = useTime(latitude, longitude, {
     updateEnabled: timeEnabled,
   });
-
+  const { weekdayFormatter } = useDateFormatter(siteUUID);
   const endDate = new Date();
   endDate.setHours(endDate.getHours() + 48);
   const graphData =

--- a/components/graphs/ThresholdGraph.tsx
+++ b/components/graphs/ThresholdGraph.tsx
@@ -19,7 +19,6 @@ import {
 
 import {
   forecastDataOverDateRange,
-  timeFormatter,
   getCurrentTimeForecastIndex,
   getGraphEndDate,
   getGraphStartDate,
@@ -30,6 +29,7 @@ import { getArrayMaxOrMinAfterIndex, Value } from 'lib/utils';
 
 import { useSiteData } from 'lib/hooks';
 import useTime from '~/lib/hooks/useTime';
+import useDateFormatter from '~/lib/hooks/useDateFormatter';
 
 const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const { forecastData, latitude, longitude, isLoading } =
@@ -38,6 +38,7 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const { currentTime } = useTime(latitude, longitude, {
     updateEnabled: timeEnabled,
   });
+  const { timeFormatter } = useDateFormatter(siteUUID);
 
   const graphData =
     forecastData &&

--- a/components/graphs/ThresholdGraph.tsx
+++ b/components/graphs/ThresholdGraph.tsx
@@ -18,7 +18,6 @@ import {
 } from '../icons/future_threshold';
 
 import {
-  forecastDataOverDateRange,
   outputDataOverDateRange,
   getCurrentTimeForecastIndex,
   getGraphEndDate,

--- a/data/site-list.json
+++ b/data/site-list.json
@@ -11,7 +11,7 @@
       "orientation": null,
       "tilt": null,
       "latitude": 50.0,
-      "longitude": 0.0,
+      "longitude": 0,
       "installed_capacity_kw": 1,
       "created_utc": "2023-02-16T01:14:29.397421+00:00",
       "updated_utc": "2023-02-16T01:14:29.397436+00:00"
@@ -27,7 +27,7 @@
       "orientation": null,
       "tilt": null,
       "latitude": 50.0,
-      "longitude": 0.0,
+      "longitude": 50.0,
       "installed_capacity_kw": 1,
       "created_utc": "2023-02-16T01:14:29.397421+00:00",
       "updated_utc": "2023-02-16T01:14:29.397436+00:00"
@@ -43,7 +43,7 @@
       "orientation": null,
       "tilt": null,
       "latitude": 50.0,
-      "longitude": 0.0,
+      "longitude": 50.0,
       "installed_capacity_kw": 1,
       "created_utc": "2023-02-16T01:14:29.397421+00:00",
       "updated_utc": "2023-02-16T01:14:29.397436+00:00"
@@ -59,7 +59,7 @@
       "orientation": null,
       "tilt": null,
       "latitude": 50.0,
-      "longitude": 0.0,
+      "longitude": 50.0,
       "installed_capacity_kw": 1,
       "created_utc": "2023-02-16T01:14:29.397421+00:00",
       "updated_utc": "2023-02-16T01:14:29.397436+00:00"

--- a/lib/graphs.ts
+++ b/lib/graphs.ts
@@ -1,16 +1,16 @@
-/**
- * Converts Date object into Hour-Minute format based on device region
- */
-export const timeFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
-  hour: 'numeric',
-  minute: 'numeric',
-});
+// /**
+//  * Converts Date object into Hour-Minute format based on device region
+//  */
+// export const timeFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
+//   hour: 'numeric',
+//   minute: 'numeric',
+// });
 
-export const weekdayFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
-  weekday: 'short',
-  hour: 'numeric',
-  minute: 'numeric',
-});
+// export const weekdayFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
+//   weekday: 'short',
+//   hour: 'numeric',
+//   minute: 'numeric',
+// });
 
 interface ForecastDataPoint {
   target_datetime_utc: number;

--- a/lib/graphs.ts
+++ b/lib/graphs.ts
@@ -9,12 +9,6 @@ export const timeFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
   minute: 'numeric',
 });
 
-// export const weekdayFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
-//   weekday: 'short',
-//   hour: 'numeric',
-//   minute: 'numeric',
-// });
-
 interface ForecastDataPoint {
   target_datetime_utc: number;
   expected_generation_kw: number;

--- a/lib/graphs.ts
+++ b/lib/graphs.ts
@@ -1,4 +1,3 @@
-
 import { ClearSkyDataPoint } from './types';
 
 /**

--- a/lib/hooks/useDateFormatter.ts
+++ b/lib/hooks/useDateFormatter.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import useSiteData from './useSiteData';
 
 /**
- * Gets forecasted and solar panel data for a single site
+ * Gets the current timezone code based on a user's site location
  * @param long the longitude value of the user's site
  * @param lat the latitude value of the user's site
  * @returns the users timezone based on mapbox's API, this returns GMT otherwise
@@ -15,6 +15,7 @@ const fetchTimeZone = async (long: number, lat: number) => {
   );
   const data = await query.json();
   // get the timezone from the resulting GeoJSON FeatureCollection
+  // temporary fix - GB is a default timezone for if the user's site location was not matched
   const userTimezone = data?.features[0]?.properties?.TZID ?? 'GB';
   return userTimezone;
 };

--- a/lib/hooks/useDateFormatter.ts
+++ b/lib/hooks/useDateFormatter.ts
@@ -1,7 +1,51 @@
+import { useEffect, useState } from 'react';
 import useSiteData from './useSiteData';
 
+/**
+ * Gets forecasted and solar panel data for a single site
+ * @param long the longitude value of the user's site
+ * @param lat the latitude value of the user's site
+ * @returns the users timezone based on mapbox's API, this returns GMT otherwise
+ */
+
+const fetchTimeZone = async (long: number, lat: number) => {
+  const query = await fetch(
+    `https://api.mapbox.com/v4/examples.4ze9z6tv/tilequery/${long},${lat}.json?access_token=${process.env.NEXT_PUBLIC_MAPBOX_PUBLIC}`,
+    { method: 'GET' }
+  );
+  const data = await query.json();
+  // get the timezone from the resulting GeoJSON FeatureCollection
+  const userTimezone = data?.features[0]?.properties?.TZID ?? 'GB';
+  return userTimezone;
+};
+
 const useDateFormatter = (siteUUID: string) => {
-  const { latitude, longitude } = useSiteData(siteUUID);
+  const { longitude, latitude } = useSiteData(siteUUID);
+  const [timezone, setTimezone] = useState(undefined);
+
+  useEffect(() => {
+    const wrapper = async () => {
+      if (longitude != undefined && latitude != undefined) {
+        setTimezone(await fetchTimeZone(longitude, latitude));
+      }
+    };
+    wrapper();
+  }, [longitude, latitude]);
+
+  const timeFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZone: timezone,
+  });
+
+  const weekdayFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
+    weekday: 'short',
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZone: timezone,
+  });
+
+  return { timezone, timeFormatter, weekdayFormatter };
 };
 
 export default useDateFormatter;

--- a/lib/hooks/useDateFormatter.ts
+++ b/lib/hooks/useDateFormatter.ts
@@ -1,0 +1,7 @@
+import useSiteData from './useSiteData';
+
+const useDateFormatter = (siteUUID: string) => {
+  const { latitude, longitude } = useSiteData(siteUUID);
+};
+
+export default useDateFormatter;


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: :rocket:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

For this issue, the general problem was that a time increments for both graph components were based on some hard coded timezone and not the actual location of the user site. I implemented a `useDataFormatter` hook that returns the timezone, timeFormatter function, and weekdayFormatter function. These functions take in a timezone parameter. The way this parameter is obtained is through a call of Mapbox's API. This call is wrapped around a use effect which has that long and lat as dependencies. 

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #147 

## Todos
- This brings up another issue, which is that the times for the threshold graph are not from 8:00 to 8:00 PM locally (they adjust based on the timezone)
<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
