### PR TITLE
Show tomorrow's threshold graph after dusk

### DIFF
--- a/components/graphs/ThresholdGraph.tsx
+++ b/components/graphs/ThresholdGraph.tsx
@@ -205,21 +205,21 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     if (!graphData) return null;
 
     const currIndex = getCurrentTimeGenerationIndex(graphData);
-    const minMax = getArrayMaxOrMinAfterIndex(graphData, currIndex);
+    const slope = getArrayMaxOrMinAfterIndex(graphData, currIndex);
 
-    if (minMax) {
-      const { type, index } = minMax;
-      const minMaxForecastDate = timeFormatter.format(
-        new Date(graphData[index].datetime_utc)
+    if (slope) {
+      const { type, endIndex } = slope;
+      const slopeForecastDate = timeFormatter.format(
+        new Date(graphData[endIndex].datetime_utc)
       );
 
       switch (type) {
-        case 'max':
-          return solarIncreasingText(minMaxForecastDate);
-        case 'min':
-          return solarDecreasingText(minMaxForecastDate);
+        case 'increasing':
+          return solarIncreasingText(slopeForecastDate);
+        case 'decreasing':
+          return solarDecreasingText(slopeForecastDate);
         case 'constant':
-          return solarConstantText(minMaxForecastDate);
+          return solarConstantText(slopeForecastDate);
         default:
           return '';
       }

--- a/components/graphs/ThresholdGraph.tsx
+++ b/components/graphs/ThresholdGraph.tsx
@@ -23,7 +23,7 @@ import {
   makeGraphable,
 } from 'lib/graphs';
 
-import { getArrayMaxOrMinAfterIndex } from 'lib/utils';
+import { getTrendAfterIndex } from 'lib/utils';
 
 import { useSiteData } from 'lib/hooks';
 import useDateFormatter from '~/lib/hooks/useDateFormatter';
@@ -205,7 +205,7 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     if (!graphData) return null;
 
     const currIndex = getCurrentTimeGenerationIndex(graphData);
-    const slope = getArrayMaxOrMinAfterIndex(graphData, currIndex);
+    const slope = getTrendAfterIndex(graphData, currIndex);
 
     if (slope) {
       const { type, endIndex } = slope;

--- a/components/graphs/ThresholdGraph.tsx
+++ b/components/graphs/ThresholdGraph.tsx
@@ -36,7 +36,7 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const { currentTime, duskTime, dawnTime } = useTime(latitude, longitude, {
     updateEnabled: timeEnabled,
   });
-  const { timeFormatter } = useDateFormatter(siteUUID);
+  const { timeFormatter, dayFormatter } = useDateFormatter(siteUUID);
 
   const graphData = useMemo(() => {
     if (forecastData && dawnTime && duskTime) {
@@ -118,9 +118,9 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   };
 
   /**
-   * @returns the start and end time label on the graph's x-axis
+   * @returns the time text below the threshold graph
    */
-  const renderStartAndEndTime = () => {
+  const renderTime = () => {
     if (!graphData) return null;
 
     const numForecastValues = graphData.length;
@@ -130,14 +130,37 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     }
 
     const startTime = timeFormatter.format(new Date(graphData[0].datetime_utc));
+    const startDay = dayFormatter.format(new Date(graphData[0].datetime_utc));
+
     const endTime = timeFormatter.format(
+      new Date(graphData[numForecastValues - 1].datetime_utc)
+    );
+    const endDay = dayFormatter.format(
       new Date(graphData[numForecastValues - 1].datetime_utc)
     );
 
     return (
       <div className="flex flex-row justify-between">
-        <p className="text-white text-xs font-medium ml-6">{startTime}</p>
-        <p className="text-white text-xs font-medium mr-6">{endTime}</p>
+        <div>
+          <p className="text-white text-xs sm:text-base font-semibold sm:font-medium ml-3 sm:ml-6">
+            {startTime}
+          </p>
+          <p className="text-white text-xs sm:text-base font-normal ml-3 sm:ml-6">
+            {startDay}
+          </p>
+        </div>
+        <div className="w-9/12 sm:w-4/6">
+          {renderCurrentTime()}
+          {getSolarActivityText()}
+        </div>
+        <div>
+          <p className="text-white text-xs sm:text-base font-semibold sm:font-medium mr-3 sm:mr-6">
+            {endTime}
+          </p>
+          <p className="text-white text-xs sm:text-base font-normal mr-3 sm:mr-6">
+            {endDay}
+          </p>
+        </div>
       </div>
     );
   };
@@ -146,7 +169,7 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     return (
       <div className="flex flex-row justify-center mt-2">
         <UpArrowIcon />
-        <p className="text-white text-sm font-normal ml-2">
+        <p className="text-white text-sm font-normal ml-1 sm:ml-2">
           Solar activity is increasing until {formattedDate}
         </p>
       </div>
@@ -157,8 +180,18 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     return (
       <div className="flex flex-row justify-center mt-2">
         <DownArrowIcon />
-        <p className="text-white text-sm font-normal ml-2">
+        <p className="text-white text-sm font-normal ml-1 sm:ml-2">
           Solar activity is decreasing until {formattedDate}
+        </p>
+      </div>
+    );
+  };
+
+  const solarConstantText = (formattedDate: string) => {
+    return (
+      <div className="flex flex-row justify-center mt-2">
+        <p className="text-white text-sm font-normal ml-2">
+          Solar activity is constant until {formattedDate}
         </p>
       </div>
     );
@@ -169,35 +202,52 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
    * and returns text indicating increasing/decreasing solar activity
    */
   const getSolarActivityText = () => {
-    if (!forecastData) return null;
+    if (!graphData) return null;
 
-    const currIndex = getCurrentTimeGenerationIndex(
-      forecastData.forecast_values
-    );
-    const minMax = getArrayMaxOrMinAfterIndex(
-      forecastData.forecast_values,
-      currIndex
-    );
+    const currIndex = getCurrentTimeGenerationIndex(graphData);
+    const minMax = getArrayMaxOrMinAfterIndex(graphData, currIndex);
 
     if (minMax) {
       const { type, index } = minMax;
       const minMaxForecastDate = timeFormatter.format(
-        new Date(forecastData.forecast_values[index].datetime_utc)
+        new Date(graphData[index].datetime_utc)
       );
-      return type === 'max'
-        ? solarIncreasingText(minMaxForecastDate)
-        : solarDecreasingText(minMaxForecastDate);
+
+      switch (type) {
+        case 'max':
+          return solarIncreasingText(minMaxForecastDate);
+        case 'min':
+          return solarDecreasingText(minMaxForecastDate);
+        case 'constant':
+          return solarConstantText(minMaxForecastDate);
+        default:
+          return '';
+      }
     }
 
     return '';
   };
 
   const renderCurrentTime = () => {
+    if (!graphData) {
+      return null;
+    }
+
+    const numForecastValues = graphData.length;
+
+    if (
+      Date.now() < graphData[0].datetime_utc.getTime() ||
+      Date.now() > graphData[numForecastValues - 1].datetime_utc.getTime()
+    ) {
+      return (
+        <p className="text-white text-base font-medium">
+          Tomorrow&apos;s Forecast
+        </p>
+      );
+    }
+
     return (
-      <p
-        suppressHydrationWarning
-        className="text-white text-base font-semibold"
-      >
+      <p suppressHydrationWarning className="text-white text-base font-medium">
         {timeFormatter.format(currentTime)}
       </p>
     );
@@ -271,10 +321,8 @@ const ThresholdGraph: FC<{ siteUUID: string }> = ({ siteUUID }) => {
           </ResponsiveContainer>
         )}
       </div>
-      <div className="flex flex-col justify-center content-center bottom-8 inset-x-0 text-center">
-        {renderStartAndEndTime()}
-        {renderCurrentTime()}
-        {getSolarActivityText()}
+      <div className="flex flex-col justify-center content-center inset-x-0 text-center">
+        {renderTime()}
       </div>
     </div>
   );

--- a/lib/hooks/useDateFormatter.ts
+++ b/lib/hooks/useDateFormatter.ts
@@ -39,6 +39,12 @@ const useDateFormatter = (siteUUID: string) => {
     timeZone: timezone,
   });
 
+  const dayFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
+    month: 'short',
+    day: 'numeric',
+    timeZone: timezone,
+  });
+
   const weekdayFormatter = new Intl.DateTimeFormat(['en-US', 'en-GB'], {
     weekday: 'short',
     hour: 'numeric',
@@ -46,7 +52,7 @@ const useDateFormatter = (siteUUID: string) => {
     timeZone: timezone,
   });
 
-  return { timezone, timeFormatter, weekdayFormatter };
+  return { timezone, dayFormatter, timeFormatter, weekdayFormatter };
 };
 
 export default useDateFormatter;

--- a/lib/hooks/useTime.ts
+++ b/lib/hooks/useTime.ts
@@ -28,10 +28,10 @@ const useTime = (
    * @returns 12:00 AM GMT-05 of the next day
    */
   const getNextDay = () => {
-    const now = new Date();
-    now.setDate(now.getDate() + 1);
-    now.setHours(0, 0, 0, 0);
-    return now;
+    const nextDay = new Date();
+    nextDay.setDate(nextDay.getDate() + 1);
+    nextDay.setHours(0, 0, 0, 0);
+    return nextDay;
   };
 
   const times = useMemo(() => {

--- a/lib/hooks/useTime.ts
+++ b/lib/hooks/useTime.ts
@@ -24,21 +24,32 @@ const useTime = (
 ) => {
   const [currentTime, setCurrentTime] = useState(Date.now());
 
-  const times = useMemo(() => {
-    // TODO: Maybe make this depend on `currentTime` to have it update.
-    // At a slower interval though...
-    const calculatedTimes =
-      latitude && longitude
-        ? SunCalc.getTimes(new Date(), latitude, longitude)
-        : null;
+  /**
+   * @returns 12:00 AM GMT-05 of the next day
+   */
+  const getNextDay = () => {
+    const now = new Date();
+    now.setDate(now.getDate() + 1);
+    now.setHours(0, 0, 0, 0);
+    return now;
+  };
 
-    if (calculatedTimes !== null) {
-      return {
-        duskTime: calculatedTimes.dusk,
-        dawnTime: calculatedTimes.dawn,
-      };
+  const times = useMemo(() => {
+    if (!(latitude && longitude)) {
+      return null;
     }
-    return null;
+
+    let calculatedTimes = SunCalc.getTimes(new Date(), latitude, longitude);
+
+    // If we are past dusk, then set the dusk and dawn time to the next day
+    if (Date.now() >= calculatedTimes.dusk) {
+      calculatedTimes = SunCalc.getTimes(getNextDay(), latitude, longitude);
+    }
+
+    return {
+      duskTime: calculatedTimes.dusk,
+      dawnTime: calculatedTimes.dawn,
+    };
   }, [latitude, longitude]);
 
   const isDayTime = useMemo(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,7 +6,6 @@ import {
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 import { getCurrentTimeGenerationIndex } from './graphs';
 import { GenerationDataPoint, SiteList } from './types';
-import { start } from 'repl';
 
 /**
  * Turn a HTML element ID string (an-element-id) into camel case (anElementId)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -20,9 +20,9 @@ export function camelCaseID(id: string) {
   return [first, ...rest.map(capitalize)].join('');
 }
 
-interface MinMaxInterface {
-  type: 'min' | 'max' | 'constant';
-  index: number;
+interface SlopeInterface {
+  type: 'increasing' | 'decreasing' | 'constant';
+  endIndex: number;
 }
 
 /**
@@ -35,11 +35,11 @@ interface MinMaxInterface {
 export const getArrayMaxOrMinAfterIndex = (
   array: GenerationDataPoint[],
   startIndex: number
-): MinMaxInterface | null => {
+): SlopeInterface | null => {
   if (startIndex === array.length - 1) {
     return {
-      type: 'min',
-      index: startIndex,
+      type: 'constant',
+      endIndex: startIndex,
     };
   }
 
@@ -61,13 +61,13 @@ export const getArrayMaxOrMinAfterIndex = (
     if (firstSlopeSign !== currentSlopeSign && currentSlopeSign !== 0) {
       // Slope was constant until current index
       if (firstSlopeSign === 0) {
-        return { type: 'constant', index: startIndex };
+        return { type: 'constant', endIndex: startIndex };
       }
 
       // Slope was negative or positive until current index
       return {
-        type: firstSlopeSign < currentSlopeSign ? 'min' : 'max',
-        index: startIndex,
+        type: firstSlopeSign < currentSlopeSign ? 'decreasing' : 'increasing',
+        endIndex: startIndex,
       };
     }
 
@@ -75,8 +75,8 @@ export const getArrayMaxOrMinAfterIndex = (
   }
 
   return {
-    type: firstSlopeSign < 0 ? 'min' : 'max',
-    index: startIndex,
+    type: firstSlopeSign < 0 ? 'decreasing' : 'increasing',
+    endIndex: startIndex,
   };
 };
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -31,7 +31,7 @@ interface SlopeInterface {
  * @param startIndex The index to start the search at
  * @returns The index of the next minimum or maximum value
  */
-export const getArrayMaxOrMinAfterIndex = (
+export const getTrendAfterIndex = (
   array: GenerationDataPoint[],
   startIndex: number
 ): SlopeInterface | null => {

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -38,7 +38,7 @@ const Sites = () => {
         <h1 className="flex-1 font-bold text-3xl text-ocf-gray">My Sites</h1>
         <button onClick={() => setEditMode(!editMode)}>
           {editMode ? (
-            <p className="text-amber text-md font-semibold">Done</p>
+            <p className="text-amber text-base font-semibold">Done</p>
           ) : (
             <EditIcon color="#E4E4E4" />
           )}


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: 🚀 

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

- Updates the `useTime()` hook to calculate the next day's dusk and dawn if the current time is after the current day's dusk. This is so the user can view the next day's solar forecast after the current day's dusk.
- Update styling for the Threshold graph based on the above.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #187 