### PR TITLE
Implement Site Profile Nav Icon

### DIFF
--- a/components/ContactButton.tsx
+++ b/components/ContactButton.tsx
@@ -1,0 +1,17 @@
+import { FC, PropsWithChildren } from 'react';
+import { useUser } from '@auth0/nextjs-auth0';
+
+const ContactButton = () => {
+  const { user } = useUser();
+  console.log(user);
+  const firstName = user && user.given_name ? user.given_name.toString() : '';
+  const lastName = user && user.family_name ? user.family_name.toString() : '';
+
+  return (
+    <button className="w-[50px] h-[50px] float-right bg-gray-300 rounded-full">
+      {firstName.substring(0, 1) + lastName.substring(0, 1)}
+    </button>
+  );
+};
+
+export default ContactButton;

--- a/components/ContactButton.tsx
+++ b/components/ContactButton.tsx
@@ -27,7 +27,7 @@ const MenuLink: React.FC<MenuLinkProps> = ({
         >
           <div className="w-[20px] h-[18px]">{svg}</div>
           <span
-            className={`ml-[30px] font-medium flex-1 align-center ${textColor} text-[12px]`}
+            className={`ml-[40px] font-medium flex-1 align-center ${textColor} text-[12px] mt-[6px]`}
           >
             {label}
           </span>
@@ -41,7 +41,6 @@ const ContactButton = () => {
   const { user } = useUser();
   const firstName = user && user.given_name ? user.given_name.toString() : '';
   const lastName = user && user.family_name ? user.family_name.toString() : '';
-  const imageURL = user && user.picture ? user.picture.toString() : '';
   const userEmail = user && user.email ? user.email.toString() : '';
 
   const [displayPopup, setDisplayPopup] = useState(false);
@@ -56,6 +55,7 @@ const ContactButton = () => {
       >
         {firstName.substring(0, 1) + lastName.substring(0, 1)}
       </button>
+
       {displayPopup && (
         <div className="w-[191px] h-[103px] absolute rounded-lg border-ocf-gray-300 border-[.5px] bg-ocf-black-900 right-0 mt-[10px]">
           <div className="flex justify-evenly">

--- a/components/ContactButton.tsx
+++ b/components/ContactButton.tsx
@@ -4,39 +4,6 @@ import { LogoutIcon } from './icons';
 import router from 'next/router';
 import Link, { LinkProps } from 'next/link';
 
-type MenuLinkProps = {
-  linkProps: LinkProps;
-  label: string;
-  svg: ReactNode;
-  currentPath: string;
-};
-
-const MenuLink: React.FC<MenuLinkProps> = ({
-  linkProps,
-  label,
-  svg,
-  currentPath,
-}) => {
-  const textColor =
-    linkProps.href === currentPath ? 'text-amber' : 'text-white';
-  return (
-    <Link {...linkProps}>
-      <a>
-        <div
-          className={`px-4 py-2 flex items-center rounded-md text-gray-600 hover:text-gray-700 hover:bg-ocf-gray-1000 transition-colors transform`}
-        >
-          <div className="w-[20px] h-[18px]">{svg}</div>
-          <span
-            className={`ml-[40px] font-medium flex-1 align-center ${textColor} text-[12px] mt-[6px]`}
-          >
-            {label}
-          </span>
-        </div>
-      </a>
-    </Link>
-  );
-};
-
 const ContactButton = () => {
   const { user } = useUser();
   const firstName = user && user.given_name ? user.given_name.toString() : '';
@@ -71,14 +38,24 @@ const ContactButton = () => {
           </div>
           <div className="w-full border-ocf-gray-800 border-[.5px] mt-[10px]"></div>
           <div className="flex flex-col gap-3">
-            <MenuLink
-              linkProps={{
-                href: `/api/auth/logout?returnTo=${process.env.NEXT_PUBLIC_AUTH0_LOGOUT_REDIRECT}`,
-              }}
-              label="Sign Out"
-              svg={<LogoutIcon />}
-              currentPath={router.asPath}
-            />
+            <Link
+              href={`/api/auth/logout?returnTo=${process.env.NEXT_PUBLIC_AUTH0_LOGOUT_REDIRECT}`}
+            >
+              <a>
+                <div
+                  className={`px-4 py-2 flex items-center rounded-md text-gray-600 hover:text-gray-700 hover:bg-ocf-gray-1000 transition-colors transform`}
+                >
+                  <div className="w-[20px] h-[18px]">
+                    <LogoutIcon />
+                  </div>
+                  <span
+                    className={`ml-[40px] font-medium flex-1 align-center text-white text-[12px] mt-[6px]`}
+                  >
+                    Sign Out
+                  </span>
+                </div>
+              </a>
+            </Link>
           </div>
         </div>
       )}

--- a/components/ContactButton.tsx
+++ b/components/ContactButton.tsx
@@ -1,16 +1,31 @@
-import { FC, PropsWithChildren } from 'react';
+import { FC, PropsWithChildren, useState } from 'react';
 import { useUser } from '@auth0/nextjs-auth0';
 
 const ContactButton = () => {
   const { user } = useUser();
-  console.log(user);
   const firstName = user && user.given_name ? user.given_name.toString() : '';
   const lastName = user && user.family_name ? user.family_name.toString() : '';
+  const imageURL = user && user.picture ? user.picture.toString() : '';
+  const [displayPopup, setDisplayPopup] = useState(false);
 
   return (
-    <button className="w-[50px] h-[50px] float-right bg-gray-300 rounded-full">
-      {firstName.substring(0, 1) + lastName.substring(0, 1)}
-    </button>
+    <div className="">
+      <button
+        className="w-[40px] h-[40px] float-right bg-[#909090] rounded-full relative text-white"
+        onClick={() =>
+          displayPopup ? setDisplayPopup(false) : setDisplayPopup(true)
+        }
+      >
+        {firstName.substring(0, 1) + lastName.substring(0, 1)}
+      </button>
+      {displayPopup && (
+        <div className="w-[200px] h-[100px] absolute rounded-lg border-[#909090] border-2 bg-ocf-black-900">
+          <div className="ml-[10px] mt-[10px] w-[40px] h-[40px] bg-[#909090] rounded-full text-white items-center">
+            {firstName.substring(0, 1) + lastName.substring(0, 1)}
+          </div>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/components/ContactButton.tsx
+++ b/components/ContactButton.tsx
@@ -1,17 +1,55 @@
-import { FC, PropsWithChildren, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { useUser } from '@auth0/nextjs-auth0';
+import { LogoutIcon } from './icons';
+import router from 'next/router';
+import Link, { LinkProps } from 'next/link';
+
+type MenuLinkProps = {
+  linkProps: LinkProps;
+  label: string;
+  svg: ReactNode;
+  currentPath: string;
+};
+
+const MenuLink: React.FC<MenuLinkProps> = ({
+  linkProps,
+  label,
+  svg,
+  currentPath,
+}) => {
+  const textColor =
+    linkProps.href === currentPath ? 'text-amber' : 'text-white';
+  return (
+    <Link {...linkProps}>
+      <a>
+        <div
+          className={`px-4 py-2 flex items-center rounded-md text-gray-600 hover:text-gray-700 hover:bg-ocf-gray-1000 transition-colors transform`}
+        >
+          <div className="w-[20px] h-[18px]">{svg}</div>
+          <span
+            className={`ml-[30px] font-medium flex-1 align-center ${textColor} text-[12px]`}
+          >
+            {label}
+          </span>
+        </div>
+      </a>
+    </Link>
+  );
+};
 
 const ContactButton = () => {
   const { user } = useUser();
   const firstName = user && user.given_name ? user.given_name.toString() : '';
   const lastName = user && user.family_name ? user.family_name.toString() : '';
   const imageURL = user && user.picture ? user.picture.toString() : '';
+  const userEmail = user && user.email ? user.email.toString() : '';
+
   const [displayPopup, setDisplayPopup] = useState(false);
 
   return (
-    <div className="">
+    <div className="relative mr-[15px]">
       <button
-        className="w-[40px] h-[40px] float-right bg-[#909090] rounded-full relative text-white"
+        className="w-[31px] h-[31px] bg-ocf-gray-800 rounded-full text-white text-[12px]"
         onClick={() =>
           displayPopup ? setDisplayPopup(false) : setDisplayPopup(true)
         }
@@ -19,9 +57,28 @@ const ContactButton = () => {
         {firstName.substring(0, 1) + lastName.substring(0, 1)}
       </button>
       {displayPopup && (
-        <div className="w-[200px] h-[100px] absolute rounded-lg border-[#909090] border-2 bg-ocf-black-900">
-          <div className="ml-[10px] mt-[10px] w-[40px] h-[40px] bg-[#909090] rounded-full text-white items-center">
-            {firstName.substring(0, 1) + lastName.substring(0, 1)}
+        <div className="w-[191px] h-[103px] absolute rounded-lg border-ocf-gray-300 border-[.5px] bg-ocf-black-900 right-0 mt-[10px]">
+          <div className="flex justify-evenly">
+            <div className="mt-[10px] w-[31px] h-[31px] bg-ocf-gray-800  rounded-full text-white flex items-center justify-center text-[12px]">
+              {firstName.substring(0, 1) + lastName.substring(0, 1)}
+            </div>
+            <div className="flex-col justify-center">
+              <div className="text-white mt-[7px] text-[12px]">
+                {firstName + ' ' + lastName}
+              </div>
+              <div className="text-white mt-[2px] text-[10px]">{userEmail}</div>
+            </div>
+          </div>
+          <div className="w-full border-ocf-gray-800 border-[.5px] mt-[10px]"></div>
+          <div className="flex flex-col gap-3">
+            <MenuLink
+              linkProps={{
+                href: `/api/auth/logout?returnTo=${process.env.NEXT_PUBLIC_AUTH0_LOGOUT_REDIRECT}`,
+              }}
+              label="Sign Out"
+              svg={<LogoutIcon />}
+              currentPath={router.asPath}
+            />
           </div>
         </div>
       )}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -27,11 +27,9 @@ const Dashboard: FC<DashboardProps> = ({ siteUUIDs }) => {
             Solar Activity
           </h2>
         </div>
-        {!isAggregate && (
-          <div className="grid-in-Sunny">
-            <SunnyTimeframe siteUUID={sites[0]} />
-          </div>
-        )}
+        <div className="grid-in-Sunny">
+          <SunnyTimeframe siteUUID={sites[0]} />
+        </div>
         <div className="grid-in-Recommendation">
           <EnergyRecommendation siteUUIDs={sites} />
         </div>
@@ -49,11 +47,9 @@ const Dashboard: FC<DashboardProps> = ({ siteUUIDs }) => {
         <div className="grid-in-Current-Output md:hidden">
           <CurrentOutput siteUUID={sites[0]} />
         </div>
-        {!isAggregate && (
-          <div className="grid-in-Weather-Icons">
-            <WeatherCard siteUUID={sites[0]} />
-          </div>
-        )}
+        <div className="grid-in-Weather-Icons">
+          <WeatherCard siteUUID={sites[0]} />
+        </div>
         <div className="grid-in-Graph">
           <Graph siteUUIDs={sites} />
         </div>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,25 +4,23 @@ import NavBar from './navigation/NavBar';
 import BottomNavBar from './navigation/BottomNavBar';
 import { useUser } from '@auth0/nextjs-auth0';
 import Transition from './navigation/Transition';
-import { useRouter } from 'next/router';
+import ContactButton from './ContactButton';
 
 const Layout: FC<PropsWithChildren> = ({ children }) => {
   const { user } = useUser();
-  const { asPath: path } = useRouter();
 
   const PageTransitionWrapper = user ? Transition : 'div';
-  const showNav = !!user && path != '/site-details';
 
   return (
     <>
       <PageTransitionWrapper className="overflow-x-clip overflow-y-auto flex-1 grid-in-content relative">
-        {showNav && <NavBar />}
+        {user && <NavBar />}
         <SideBar />
         <main className="bg-white dark:bg-ocf-black flex flex-col items-center justify-start w-full">
           {children}
         </main>
       </PageTransitionWrapper>
-      {showNav && <BottomNavBar />}
+      {user && <BottomNavBar />}
     </>
   );
 };

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -15,7 +15,11 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
     <>
       <PageTransitionWrapper className="overflow-x-clip overflow-y-auto flex-1 grid-in-content relative">
         {user && <NavBar />}
-        <ContactButton></ContactButton>
+        {user && (
+          <div className="flex justify-end">
+            <ContactButton />
+          </div>
+        )}
         <SideBar />
         <main className="bg-white dark:bg-ocf-black flex flex-col items-center justify-start w-full">
           {children}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,6 +4,7 @@ import NavBar from './navigation/NavBar';
 import BottomNavBar from './navigation/BottomNavBar';
 import { useUser } from '@auth0/nextjs-auth0';
 import Transition from './navigation/Transition';
+import ContactButton from './ContactButton';
 
 const Layout: FC<PropsWithChildren> = ({ children }) => {
   const { user } = useUser();
@@ -14,6 +15,7 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
     <>
       <PageTransitionWrapper className="overflow-x-clip overflow-y-auto flex-1 grid-in-content relative">
         {user && <NavBar />}
+        <ContactButton></ContactButton>
         <SideBar />
         <main className="bg-white dark:bg-ocf-black flex flex-col items-center justify-start w-full">
           {children}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,23 +4,25 @@ import NavBar from './navigation/NavBar';
 import BottomNavBar from './navigation/BottomNavBar';
 import { useUser } from '@auth0/nextjs-auth0';
 import Transition from './navigation/Transition';
-import ContactButton from './ContactButton';
+import { useRouter } from 'next/router';
 
 const Layout: FC<PropsWithChildren> = ({ children }) => {
   const { user } = useUser();
 
   const PageTransitionWrapper = user ? Transition : 'div';
+  const { asPath: path } = useRouter();
+  const showNav = !!user && path != '/site-details';
 
   return (
     <>
       <PageTransitionWrapper className="overflow-x-clip overflow-y-auto flex-1 grid-in-content relative">
-        {user && <NavBar />}
+        {showNav && <NavBar />}
         <SideBar />
         <main className="bg-white dark:bg-ocf-black flex flex-col items-center justify-start w-full">
           {children}
         </main>
       </PageTransitionWrapper>
-      {user && <BottomNavBar />}
+      {showNav && <BottomNavBar />}
     </>
   );
 };

--- a/components/icons/LogoutIcon.tsx
+++ b/components/icons/LogoutIcon.tsx
@@ -4,7 +4,7 @@ const LogoutIcon: React.FC = ({}) => (
     fill="none"
     viewBox="0 0 24 24"
     className="w-6 h-6"
-    stroke={'currentColor'}
+    stroke={'white'}
     strokeWidth={1.5}
   >
     <path


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: :rocket:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
For this feature, I built out a `<ContactButton />` component that displays a small circle (like gmail does) of the users initials that they can click on to see more about their account info. The component is based off the figma designs, displays the name, email, and provides a user with the option to sign out as well. for the Sign Out feature I copied the current implementation of the button in the sidebar and altered a few styling points. 
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #213 

## Todos
- Consider refactoring the copy/past menulink code
<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
<img width="244" alt="Screenshot 2023-04-17 at 8 48 09 PM" src="https://user-images.githubusercontent.com/67704979/232648776-2c256f6b-fb37-4f89-9d42-5e32e868f705.png">
