### PR TITLE
Add profile icon to navbar

### DIFF
--- a/components/ContactButton.tsx
+++ b/components/ContactButton.tsx
@@ -24,7 +24,7 @@ const ContactButton = () => {
       </button>
 
       {displayPopup && (
-        <div className="w-[191px] h-[103px] absolute rounded-lg border-ocf-gray-300 border-[.5px] bg-ocf-black-900 right-0 mt-[10px]">
+        <div className="w-[191px] h-[103px] absolute rounded-lg border-ocf-gray-300 border-[.5px] bg-ocf-black-900 right-0 mt-[10px] z-10">
           <div className="flex justify-evenly">
             <div className="mt-[10px] w-[31px] h-[31px] bg-ocf-gray-800  rounded-full text-white flex items-center justify-center text-[12px]">
               {firstName.substring(0, 1) + lastName.substring(0, 1)}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import SunnyTimeframe from './dashboard-modules/SunnyTimeframe';
 import Graph from './graphs/Graph';
 import { SiteList } from '~/lib/types';
 import CurrentOutput from './dashboard-modules/CurrentOutput';
+import ContactButton from './ContactButton';
 
 interface DashboardProps {
   siteUUIDs: SiteList;
@@ -18,12 +19,19 @@ const Dashboard: FC<DashboardProps> = ({ siteUUIDs }) => {
   const { client_site_name } = useSiteData(sites[0]);
   return (
     <div className="bg-ocf-black max-w-screen-xl w-screen min-h-screen px-4 mb-[var(--bottom-nav-margin)]">
-      <h1 className="mt-4 mb-4 text-ocf-gray text-3xl font-bold">
-        {isAggregate ? 'Aggregate Dashboard' : client_site_name}
-      </h1>
+      <div className="flex flex-row justify-between items-center">
+        <h1 className="mt-2 mb-3 text-ocf-gray text-2xl md:text-3xl font-semibold">
+          {/* may have visual issues if client site name is too long */}
+          {isAggregate ? 'Aggregate Dashboard' : client_site_name}
+        </h1>
+        <div className="block md:hidden">
+          <ContactButton />
+        </div>
+      </div>
+      <hr className="w-[500%] mx-[-100px] bg-ocf-black-500 border-0 h-[1px] md:hidden" />
       <div className="grid grid-areas-dashboard-mobile grid-cols-mobile-columns grid-rows-mobile-rows md:grid-areas-dashboard-desktop md:grid-cols-desktop-columns md:grid-rows-desktop-rows w-full gap-4">
         <div className="grid-in-Heading1 block md:hidden">
-          <h2 className="text-ocf-gray text-base font-semibold leading-none mt-2">
+          <h2 className="text-ocf-gray text-base font-semibold leading-none mt-3">
             Solar Activity
           </h2>
         </div>

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -77,8 +77,9 @@ const NavBar: FC = () => {
           currentPath={router.asPath}
           href="/more-info"
         />
-
-        <ContactButton/>
+        <div className="hidden md:block">
+          <ContactButton />
+        </div>
       </div>
     </div>
   );

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -46,6 +46,13 @@ const NavBar: FC = () => {
     openSideBar();
   };
 
+  const getInitials = () => {
+    const initials = user?.name
+      ?.split(' ')
+      .reduce((prevInitials, name) => prevInitials + name[0], '');
+    return initials || '';
+  };
+
   return (
     <div
       className={`bg-ocf-black max-w-screen-xl w-screen h-[var(--nav-height)] mx-auto flex ${
@@ -76,6 +83,9 @@ const NavBar: FC = () => {
           currentPath={router.asPath}
           href="/more-info"
         />
+        <div className="bg-ocf-gray-800 text-white text-center text-xs w-6 h-6 leading-6 rounded-full">
+          {getInitials()}
+        </div>
       </div>
     </div>
   );

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -6,6 +6,7 @@ import { SiteList } from '~/lib/types';
 import { MenuLogo, NowcastingLogo } from '../icons/NavbarIcons';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import ContactButton from '../ContactButton';
 
 type NavbarLinkProps = {
   title: string;
@@ -46,13 +47,6 @@ const NavBar: FC = () => {
     openSideBar();
   };
 
-  const getInitials = () => {
-    const initials = user?.name
-      ?.split(' ')
-      .reduce((prevInitials, name) => prevInitials + name[0], '');
-    return initials || '';
-  };
-
   return (
     <div
       className={`bg-ocf-black max-w-screen-xl w-screen h-[var(--nav-height)] mx-auto flex ${
@@ -83,9 +77,8 @@ const NavBar: FC = () => {
           currentPath={router.asPath}
           href="/more-info"
         />
-        <div className="bg-ocf-gray-800 text-white text-center text-xs w-6 h-6 leading-6 rounded-full">
-          {getInitials()}
-        </div>
+
+        <ContactButton/>
       </div>
     </div>
   );

--- a/components/navigation/NavBar.tsx
+++ b/components/navigation/NavBar.tsx
@@ -23,7 +23,7 @@ const NavbarLink: React.FC<NavbarLinkProps> = ({
   return (
     <Link href={href} passHref>
       <a
-        className={`${textColor} text-lg font-medium mr-6 ${
+        className={`${textColor} text-lg font-medium mr-6 hidden md:block  ${
           isActive && 'underline underline-offset-8 decoration-2'
         }`}
       >


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: 🚀 

## Description

- Adds a profile icon to the navbar.
- Hides the navbar links on mobile view.
- Changes dashboard heading in line with figma 

Fixes #220

## Screenshots

Desktop View
<img width="1217" alt="Screen Shot 2023-04-22 at 10 18 34 PM" src="https://user-images.githubusercontent.com/62641231/233817850-4c0d09dc-fa95-4bd5-9b1a-f0542b84a5cd.png">

Mobile View
<img width="428" alt="Screen Shot 2023-04-22 at 10 18 46 PM" src="https://user-images.githubusercontent.com/62641231/233817854-7732dc27-ce2f-459f-8799-e6b96bea8ee3.png">


