### PR TITLE
Implement supported inverter brands on inverter page

### DIFF
--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -6,13 +6,13 @@ import { ChevronRightIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { useRouter } from 'next/router';
 import { fetcher } from '~/lib/swr';
 import { useIsMobile } from '~/lib/utils';
-import ema from '../../../public/inverters/ema.png';
-import enphase from '../../../public/inverters/enphase.png';
-import fronius from '../../../public/inverters/fronius.png';
-import goodwe from '../../../public/inverters/goodwe.png';
-import growatt from '../../../public/inverters/growatt.png';
-import solaredge from '../../../public/inverters/solaredge.png';
-import solis from '../../../public/inverters/solis.png';
+import ema from '~/public/inverters/ema.png';
+import enphase from '~/public/inverters/enphase.png';
+import fronius from '~/public/inverters/fronius.png';
+import goodwe from '~/public/inverters/goodwe.png';
+import growatt from '~/public/inverters/growatt.png';
+import solaredge from '~/public/inverters/solaredge.png';
+import solis from '~/public/inverters/solis.png';
 
 const brands = {
   EMA: ema,
@@ -32,7 +32,7 @@ const SupportedInverters = () => {
           <div key={brand} className="flex flex-row">
             <img
               src={brands[brand as keyof typeof brands].src}
-              alt={brand}
+              alt={`${brand} logo`}
             ></img>
             <div className="my-2 self-center text-ocf-gray-300">{brand}</div>
           </div>

--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -2,10 +2,11 @@ import Link from 'next/link';
 import { FC, useState } from 'react';
 import Button from '../Button';
 import InverterGraphicIcon from '../icons/InverterGraphicIcon';
-import { ChevronRightIcon } from '@heroicons/react/24/solid';
+import { ChevronRightIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { useRouter } from 'next/router';
 import { fetcher } from '~/lib/swr';
 import { useIsMobile } from '~/lib/utils';
+import Modal from '~/lib/components/Modal';
 import ema from '../../../public/inverters/ema.png';
 import enphase from '../../../public/inverters/enphase.png';
 import fronius from '../../../public/inverters/fronius.png';
@@ -16,6 +17,7 @@ import solis from '../../../public/inverters/solis.png';
 
 const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const [showInfo, setShowInfo] = useState(false);
+  const [showModal, setShowModal] = useState<boolean>(false);
   const isMobile = useIsMobile();
   const router = useRouter();
 
@@ -74,7 +76,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
         <div className="mt-10 self-center text-ocf-gray-300">
           Supported Inverters
         </div>
-        <div className="mt-2 max-h-44 self-center overflow-y-scroll px-6">
+        <div className="mt-3 max-h-44 self-center overflow-y-scroll px-6">
           <div className="flex flex-row">
             <img src={ema.src} alt="ema"></img>
             <div className="my-2 self-center text-ocf-gray-300">EMA</div>
@@ -115,6 +117,82 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
           Yes, link my inverter
         </Button>
       </a>
+
+      <button
+        className="mt-4 hidden w-full self-center text-[14px] font-semibold text-ocf-yellow md:block"
+        onClick={() => setShowModal(true)}
+      >
+        View supported inverters
+      </button>
+
+      {showModal && (
+        <div
+          className="fixed inset-0 flex h-full w-full items-center justify-center bg-ocf-black bg-opacity-50"
+          onClick={() => setShowModal(false)}
+        >
+          <div
+            className="h-auto rounded-lg bg-ocf-gray-1000 px-4 py-3 text-white opacity-100"
+            onClick={(e: React.MouseEvent<HTMLInputElement>) =>
+              e.stopPropagation()
+            }
+          >
+            <div className="flex flex-col self-center">
+              <div className="flex w-full justify-end">
+                <div className="flex-grow" />
+                <button className="w-fit" onClick={() => setShowModal(false)}>
+                  <XMarkIcon className="h-5 w-5"></XMarkIcon>
+                </button>
+              </div>
+              <div className="text-center text-ocf-gray-300">
+                Supported Inverters
+              </div>
+              <div className="mt-3 max-h-56 self-center overflow-y-scroll px-6">
+                <div className="flex flex-row">
+                  <img src={ema.src} alt="ema"></img>
+                  <div className="my-2 self-center text-ocf-gray-300">EMA</div>
+                </div>
+                <div className="flex flex-row">
+                  <img src={enphase.src} alt="ema"></img>
+                  <div className="my-2 self-center text-ocf-gray-300">
+                    Enphase
+                  </div>
+                </div>
+                <div className="flex flex-row">
+                  <img src={fronius.src} alt="ema"></img>
+                  <div className="my-2 self-center text-ocf-gray-300">
+                    Fronius
+                  </div>
+                </div>
+                <div className="flex flex-row">
+                  <img src={goodwe.src} alt="ema"></img>
+                  <div className="my-2 self-center text-ocf-gray-300">
+                    GoodWe
+                  </div>
+                </div>
+                <div className="flex flex-row">
+                  <img src={growatt.src} alt="ema"></img>
+                  <div className="my-2 self-center text-ocf-gray-300">
+                    Growatt
+                  </div>
+                </div>
+                <div className="flex flex-row">
+                  <img src={solaredge.src} alt="ema"></img>
+                  <div className="my-2 self-center text-ocf-gray-300">
+                    SolarEdge
+                  </div>
+                </div>
+                <div className="flex flex-row">
+                  <img src={solis.src} alt="ema"></img>
+                  <div className="my-2 self-center text-ocf-gray-300">
+                    Solis
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="mx-auto mb-3 mt-3 flex justify-end md:mb-8 md:mt-auto md:w-10/12">
         <Link href={isMobile ? '/sites' : `/dashboard/${siteUUID}`} passHref>
           <a className={mobileSkipButtonClass}>

--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -6,6 +6,13 @@ import { ChevronRightIcon } from '@heroicons/react/24/solid';
 import { useRouter } from 'next/router';
 import { fetcher } from '~/lib/swr';
 import { useIsMobile } from '~/lib/utils';
+import ema from '../../../public/inverters/ema.png';
+import enphase from '../../../public/inverters/enphase.png';
+import fronius from '../../../public/inverters/fronius.png';
+import goodwe from '../../../public/inverters/goodwe.png';
+import growatt from '../../../public/inverters/growatt.png';
+import solaredge from '../../../public/inverters/solaredge.png';
+import solis from '../../../public/inverters/solis.png';
 
 const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const [showInfo, setShowInfo] = useState(false);
@@ -33,7 +40,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
       <div className="mt-[40px] self-center md:mt-[0px]">
         <InverterGraphicIcon />
       </div>
-      <div className="mt-[30px] self-center text-[20px] text-white md:w-[485px] md:text-[24px]">
+      <div className="mx-8 mt-[30px] self-center text-[20px] text-white md:w-[485px] md:text-[24px]">
         Would you like to link your inverter with Enode to provide better
         forecasting?
       </div>
@@ -45,7 +52,6 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
           What&apos;s this?
         </button>
       )}
-
       <div
         className={`mt-[20px] w-full self-center text-[14px] text-ocf-gray-300 md:block md:w-[485px] ${
           showInfo ? 'block' : 'hidden'
@@ -55,17 +61,52 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
         data, providing you with better forecasts and more information available
         within our app.
       </div>
-
       {showInfo && (
         <button
-          className="mt-[5px] block w-full self-center text-right text-[14px] text-ocf-yellow underline md:hidden"
+          className="mt-[5px] w-full self-center text-center text-[14px] text-ocf-yellow underline md:hidden"
           onClick={() => setShowInfo(false)}
         >
           Show less
         </button>
       )}
 
-      <a className="mt-auto self-center md:mt-5">
+      <div className="block self-center md:hidden">
+        <div className="mt-10 self-center text-ocf-gray-300">
+          Supported Inverters
+        </div>
+        <div className="mt-2 max-h-44 self-center overflow-y-scroll px-6">
+          <div className="flex flex-row">
+            <img src={ema.src} alt="ema"></img>
+            <div className="my-2 self-center text-ocf-gray-300">EMA</div>
+          </div>
+          <div className="flex flex-row">
+            <img src={enphase.src} alt="ema"></img>
+            <div className="my-2 self-center text-ocf-gray-300">Enphase</div>
+          </div>
+          <div className="flex flex-row">
+            <img src={fronius.src} alt="ema"></img>
+            <div className="my-2 self-center text-ocf-gray-300">Fronius</div>
+          </div>
+          <div className="flex flex-row">
+            <img src={goodwe.src} alt="ema"></img>
+            <div className="my-2 self-center text-ocf-gray-300">GoodWe</div>
+          </div>
+          <div className="flex flex-row">
+            <img src={growatt.src} alt="ema"></img>
+            <div className="my-2 self-center text-ocf-gray-300">Growatt</div>
+          </div>
+          <div className="flex flex-row">
+            <img src={solaredge.src} alt="ema"></img>
+            <div className="my-2 self-center text-ocf-gray-300">SolarEdge</div>
+          </div>
+          <div className="flex flex-row">
+            <img src={solis.src} alt="ema"></img>
+            <div className="my-2 self-center text-ocf-gray-300">Solis</div>
+          </div>
+        </div>
+      </div>
+
+      <a className="mt-10 self-center md:mt-5">
         <Button
           variant="outlined"
           onClick={getLinkAndRedirect}
@@ -74,7 +115,6 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
           Yes, link my inverter
         </Button>
       </a>
-
       <div className="mx-auto mb-3 mt-3 flex justify-end md:mb-8 md:mt-auto md:w-10/12">
         <Link href={isMobile ? '/sites' : `/dashboard/${siteUUID}`} passHref>
           <a className={mobileSkipButtonClass}>

--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -65,7 +65,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     'flex items-center text-ocf-yellow text-[14px] mt-[5px]';
 
   return (
-    <div className="flex min-h-[70vh] w-full flex-col px-5 md:mt-[75px]">
+    <div className="flex h-full w-full flex-col px-5 md:mt-[75px]">
       <div className="mt-[40px] self-center md:mt-[0px]">
         <InverterGraphicIcon />
       </div>
@@ -82,7 +82,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
 
       {showInfoModal && (
         <div
-          className="fixed inset-0 flex h-full w-full items-center justify-center bg-ocf-black bg-opacity-50"
+          className="fixed inset-0 flex h-screen w-full items-center justify-center bg-ocf-black bg-opacity-50"
           onClick={() => setShowInfoModal(false)}
         >
           <div

--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -30,7 +30,7 @@ const SupportedInverters = () => {
     <div>
       {Object.keys(brands).map((brand) => {
         return (
-          <div className="flex flex-row">
+          <div key={brand} className="flex flex-row">
             <img
               src={brands[brand as keyof typeof brands].src}
               alt={brand}
@@ -45,7 +45,8 @@ const SupportedInverters = () => {
 
 const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const [showInfo, setShowInfo] = useState(false);
-  const [showModal, setShowModal] = useState<boolean>(false);
+  const [showInfoModal, setShowInfoModal] = useState<boolean>(false);
+  const [showInvertersModal, setShowInvertersModal] = useState<boolean>(false);
   const isMobile = useIsMobile();
   const router = useRouter();
 
@@ -77,28 +78,49 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
       {!showInfo && (
         <button
           className="mt-[5px] block w-full self-center text-right text-[14px] text-ocf-yellow underline md:hidden"
-          onClick={() => setShowInfo(true)}
+          onClick={() => setShowInfoModal(true)}
         >
           What&apos;s this?
         </button>
       )}
+
+      {showInfoModal && (
+        <div
+          className="fixed inset-0 flex h-full w-full items-center justify-center bg-ocf-black bg-opacity-50"
+          onClick={() => setShowInfoModal(false)}
+        >
+          <div
+            className="h-auto rounded-lg bg-ocf-gray-1000 px-4 py-3 text-white opacity-100"
+            onClick={(e: React.MouseEvent<HTMLInputElement>) =>
+              e.stopPropagation()
+            }
+          >
+            <div className="mt-[15px] block w-[225px] self-center text-[14px] text-ocf-gray-300 md:block md:w-[485px]">
+              Linking your inverter with Enode gives us access to your solar
+              output data, providing you with better forecasts and more
+              information available within our app.
+            </div>
+            <div className="w-100 flex h-auto items-center justify-end">
+              <button
+                className="block h-8 w-20 rounded-md bg-ocf-yellow text-center text-xs font-bold text-ocf-black shadow transition duration-150"
+                onClick={() => setShowInfoModal(false)}
+              >
+                Got it!
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <div
-        className={`mt-[20px] w-full self-center text-[14px] text-ocf-gray-300 md:block md:w-[485px] ${
-          showInfo ? 'block' : 'hidden'
-        }`}
+        className={
+          'mt-[20px] hidden self-center text-[14px] text-ocf-gray-300 md:block md:w-[485px]'
+        }
       >
         Linking your inverter with Enode gives us access to your solar output
         data, providing you with better forecasts and more information available
         within our app.
       </div>
-      {showInfo && (
-        <button
-          className="mt-[5px] w-full self-center text-center text-[14px] text-ocf-yellow underline md:hidden"
-          onClick={() => setShowInfo(false)}
-        >
-          Show less
-        </button>
-      )}
 
       <div className="block self-center md:hidden">
         <div className="mt-10 self-center text-ocf-gray-300">
@@ -121,15 +143,15 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
 
       <button
         className="mt-4 hidden w-full self-center text-[14px] font-semibold text-ocf-yellow md:block"
-        onClick={() => setShowModal(true)}
+        onClick={() => setShowInvertersModal(true)}
       >
         View supported inverters
       </button>
 
-      {showModal && (
+      {showInvertersModal && (
         <div
           className="fixed inset-0 flex h-full w-full items-center justify-center bg-ocf-black bg-opacity-50"
-          onClick={() => setShowModal(false)}
+          onClick={() => setShowInvertersModal(false)}
         >
           <div
             className="h-auto rounded-lg bg-ocf-gray-1000 px-4 py-3 text-white opacity-100"
@@ -140,7 +162,10 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
             <div className="flex flex-col self-center">
               <div className="flex w-full justify-end">
                 <div className="flex-grow" />
-                <button className="w-fit" onClick={() => setShowModal(false)}>
+                <button
+                  className="w-fit"
+                  onClick={() => setShowInvertersModal(false)}
+                >
                   <XMarkIcon className="h-5 w-5"></XMarkIcon>
                 </button>
               </div>

--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -86,7 +86,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
           onClick={() => setShowInfoModal(false)}
         >
           <div
-            className="h-auto rounded-lg bg-ocf-gray-1000 px-4 py-3 text-white opacity-100"
+            className="h-auto rounded-lg bg-ocf-black-500 px-4 py-3 text-white opacity-100"
             onClick={(e: React.MouseEvent<HTMLInputElement>) =>
               e.stopPropagation()
             }
@@ -138,7 +138,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
       </a>
 
       <button
-        className="mt-4 hidden w-full self-center text-[14px] font-semibold text-ocf-yellow md:block"
+        className="mt-4 hidden w-full self-center text-[14px] text-ocf-yellow md:block"
         onClick={() => setShowInvertersModal(true)}
       >
         View supported inverters
@@ -150,7 +150,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
           onClick={() => setShowInvertersModal(false)}
         >
           <div
-            className="h-auto rounded-lg bg-ocf-gray-1000 px-4 py-3 text-white opacity-100"
+            className="h-auto rounded-lg bg-ocf-black-500 px-4 py-3 text-white opacity-100"
             onClick={(e: React.MouseEvent<HTMLInputElement>) =>
               e.stopPropagation()
             }
@@ -165,10 +165,10 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
                   <XMarkIcon className="h-5 w-5"></XMarkIcon>
                 </button>
               </div>
-              <div className="text-center text-ocf-gray-300">
+              <div className="text-center text-ocf-gray-300 mx-10">
                 Supported Inverters
               </div>
-              <div className="mt-3 max-h-56 self-center overflow-y-scroll px-6">
+              <div className="mt-3 self-center px-6">
                 {SupportedInverters()}
               </div>
             </div>

--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -15,6 +15,34 @@ import growatt from '../../../public/inverters/growatt.png';
 import solaredge from '../../../public/inverters/solaredge.png';
 import solis from '../../../public/inverters/solis.png';
 
+const brands = {
+  EMA: ema,
+  Enphase: enphase,
+  Fronius: fronius,
+  Goodwe: goodwe,
+  Growatt: growatt,
+  SolarEdge: solaredge,
+  Solis: solis,
+} as const;
+
+const SupportedInverters = () => {
+  return (
+    <div>
+      {Object.keys(brands).map((brand) => {
+        return (
+          <div className="flex flex-row">
+            <img
+              src={brands[brand as keyof typeof brands].src}
+              alt={brand}
+            ></img>
+            <div className="my-2 self-center text-ocf-gray-300">{brand}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
 const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
   const [showInfo, setShowInfo] = useState(false);
   const [showModal, setShowModal] = useState<boolean>(false);
@@ -77,34 +105,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
           Supported Inverters
         </div>
         <div className="mt-3 max-h-44 self-center overflow-y-scroll px-6">
-          <div className="flex flex-row">
-            <img src={ema.src} alt="ema"></img>
-            <div className="my-2 self-center text-ocf-gray-300">EMA</div>
-          </div>
-          <div className="flex flex-row">
-            <img src={enphase.src} alt="ema"></img>
-            <div className="my-2 self-center text-ocf-gray-300">Enphase</div>
-          </div>
-          <div className="flex flex-row">
-            <img src={fronius.src} alt="ema"></img>
-            <div className="my-2 self-center text-ocf-gray-300">Fronius</div>
-          </div>
-          <div className="flex flex-row">
-            <img src={goodwe.src} alt="ema"></img>
-            <div className="my-2 self-center text-ocf-gray-300">GoodWe</div>
-          </div>
-          <div className="flex flex-row">
-            <img src={growatt.src} alt="ema"></img>
-            <div className="my-2 self-center text-ocf-gray-300">Growatt</div>
-          </div>
-          <div className="flex flex-row">
-            <img src={solaredge.src} alt="ema"></img>
-            <div className="my-2 self-center text-ocf-gray-300">SolarEdge</div>
-          </div>
-          <div className="flex flex-row">
-            <img src={solis.src} alt="ema"></img>
-            <div className="my-2 self-center text-ocf-gray-300">Solis</div>
-          </div>
+          {SupportedInverters()}
         </div>
       </div>
 
@@ -147,46 +148,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
                 Supported Inverters
               </div>
               <div className="mt-3 max-h-56 self-center overflow-y-scroll px-6">
-                <div className="flex flex-row">
-                  <img src={ema.src} alt="ema"></img>
-                  <div className="my-2 self-center text-ocf-gray-300">EMA</div>
-                </div>
-                <div className="flex flex-row">
-                  <img src={enphase.src} alt="ema"></img>
-                  <div className="my-2 self-center text-ocf-gray-300">
-                    Enphase
-                  </div>
-                </div>
-                <div className="flex flex-row">
-                  <img src={fronius.src} alt="ema"></img>
-                  <div className="my-2 self-center text-ocf-gray-300">
-                    Fronius
-                  </div>
-                </div>
-                <div className="flex flex-row">
-                  <img src={goodwe.src} alt="ema"></img>
-                  <div className="my-2 self-center text-ocf-gray-300">
-                    GoodWe
-                  </div>
-                </div>
-                <div className="flex flex-row">
-                  <img src={growatt.src} alt="ema"></img>
-                  <div className="my-2 self-center text-ocf-gray-300">
-                    Growatt
-                  </div>
-                </div>
-                <div className="flex flex-row">
-                  <img src={solaredge.src} alt="ema"></img>
-                  <div className="my-2 self-center text-ocf-gray-300">
-                    SolarEdge
-                  </div>
-                </div>
-                <div className="flex flex-row">
-                  <img src={solis.src} alt="ema"></img>
-                  <div className="my-2 self-center text-ocf-gray-300">
-                    Solis
-                  </div>
-                </div>
+                {SupportedInverters()}
               </div>
             </div>
           </div>

--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -65,7 +65,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
     'flex items-center text-ocf-yellow text-[14px] mt-[5px]';
 
   return (
-    <div className="flex h-full w-full flex-col px-5 md:mt-[75px]">
+    <div className="flex h-[90vh] w-full flex-col px-5 md:overflow-hidden md:pb-6 md:pt-[75px]">
       <div className="mt-[40px] self-center md:mt-[0px]">
         <InverterGraphicIcon />
       </div>
@@ -82,7 +82,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
 
       {showInfoModal && (
         <div
-          className="fixed inset-0 flex h-screen w-full items-center justify-center bg-ocf-black bg-opacity-50"
+          className="fixed inset-0 flex h-[var(--onboarding-height)] w-full items-center justify-center bg-ocf-black bg-opacity-50"
           onClick={() => setShowInfoModal(false)}
         >
           <div
@@ -165,7 +165,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
                   <XMarkIcon className="h-5 w-5"></XMarkIcon>
                 </button>
               </div>
-              <div className="text-center text-ocf-gray-300 mx-10">
+              <div className="mx-10 text-center text-ocf-gray-300">
                 Supported Inverters
               </div>
               <div className="mt-3 self-center px-6">
@@ -176,7 +176,7 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
         </div>
       )}
 
-      <div className="mx-auto mb-3 mt-3 flex justify-end md:mb-8 md:mt-auto md:w-10/12">
+      <div className="mx-auto my-3 flex justify-end md:mt-auto md:w-10/12">
         <Link href={isMobile ? '/sites' : `/dashboard/${siteUUID}`} passHref>
           <a className={mobileSkipButtonClass}>
             Skip this step{' '}

--- a/lib/components/form/LinkInverters.tsx
+++ b/lib/components/form/LinkInverters.tsx
@@ -6,7 +6,6 @@ import { ChevronRightIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { useRouter } from 'next/router';
 import { fetcher } from '~/lib/swr';
 import { useIsMobile } from '~/lib/utils';
-import Modal from '~/lib/components/Modal';
 import ema from '../../../public/inverters/ema.png';
 import enphase from '../../../public/inverters/enphase.png';
 import fronius from '../../../public/inverters/fronius.png';
@@ -44,7 +43,6 @@ const SupportedInverters = () => {
 };
 
 const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
-  const [showInfo, setShowInfo] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState<boolean>(false);
   const [showInvertersModal, setShowInvertersModal] = useState<boolean>(false);
   const isMobile = useIsMobile();
@@ -75,14 +73,12 @@ const LinkInverters: FC<{ siteUUID: string }> = ({ siteUUID }) => {
         Would you like to link your inverter with Enode to provide better
         forecasting?
       </div>
-      {!showInfo && (
-        <button
-          className="mt-[5px] block w-full self-center text-right text-[14px] text-ocf-yellow underline md:hidden"
-          onClick={() => setShowInfoModal(true)}
-        >
-          What&apos;s this?
-        </button>
-      )}
+      <button
+        className="mt-[5px] block w-full self-center text-right text-[14px] text-ocf-yellow underline md:hidden"
+        onClick={() => setShowInfoModal(true)}
+      >
+        What&apos;s this?
+      </button>
 
       {showInfoModal && (
         <div


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: 🚧

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Display the icons for all the inverters that are supported by Enode. On mobile, this will look like a lil scrolling section, and on desktop, this will be in a modal.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #252

## Todos
Improve styling
- better align inverter brand names/logos
- center info modal

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots
<img width="277" alt="image" src="https://user-images.githubusercontent.com/80798381/235227215-0b4eb1f8-7752-4a11-afa3-34e842e8c3a9.png">
<img width="275" alt="image" src="https://user-images.githubusercontent.com/80798381/235279535-e99987c2-cdf1-456e-9e3c-e36c0a018fb2.png">
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/80798381/235281337-edcd7f5b-340b-4e02-8d1c-56f5670b569d.png">

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
