### PR TITLE
Implement correct tomorrow behavior on threshold graph

### DIFF
--- a/lib/components/graphs/ThresholdGraph.tsx
+++ b/lib/components/graphs/ThresholdGraph.tsx
@@ -46,10 +46,18 @@ const ThresholdGraph: FC<ThresholdGraphProps> = ({ sites }) => {
   const [timeEnabled, setTimeEnabled] = useState(
     totalForecastedGeneration !== undefined
   );
-  const { currentTime, sunrise, sunset, timeFormat, weekdayFormat, timezone } =
-    useSiteTime(representativeSite, {
-      updateEnabled: timeEnabled,
-    });
+  const {
+    currentTime,
+    isAfterDayTime,
+    sunrise,
+    sunset,
+    tomorrowTimes,
+    timeFormat,
+    weekdayFormat,
+    timezone,
+  } = useSiteTime(representativeSite, {
+    updateEnabled: timeEnabled,
+  });
 
   const thresholdCapacityKW = totalInstalledCapacityKw * graphThreshold;
 
@@ -57,8 +65,8 @@ const ThresholdGraph: FC<ThresholdGraphProps> = ({ sites }) => {
     if (totalForecastedGeneration && sunrise && sunset) {
       return generationDataOverDateRange(
         totalForecastedGeneration,
-        sunrise,
-        sunset
+        isAfterDayTime ? tomorrowTimes.sunrise : sunrise,
+        isAfterDayTime ? tomorrowTimes.sunset : sunset
       );
     }
     return null;

--- a/lib/time.ts
+++ b/lib/time.ts
@@ -28,9 +28,12 @@ export const useSiteTime = (
     latitude && longitude ? ['/timezone', longitude, latitude] : null,
     () => fetchTimeZone(latitude, longitude)
   );
+
   const [currentTime, setCurrentTime] = useState(dayjs().tz(timezone));
+  const [tomorrow, setTomorrow] = useState(currentTime.add(1, 'day'));
 
   useEffect(() => setCurrentTime(dayjs().tz(timezone)), [timezone]);
+  useEffect(() => setTomorrow(currentTime.add(1, 'day')), [currentTime]);
 
   useEffect(() => {
     if (updateEnabled) {
@@ -48,10 +51,20 @@ export const useSiteTime = (
     [currentTime, latitude, longitude]
   );
 
+  const tomorrowTimes = useMemo(
+    () => SunCalc.getTimes(tomorrow.toDate(), latitude, longitude),
+    [tomorrow, latitude, longitude]
+  );
+
   const isDayTime = useMemo(
     () =>
       currentTime.isAfter(dayjs(times.sunrise)) &&
       currentTime.isBefore(dayjs(times.sunset)),
+    [currentTime, times]
+  );
+
+  const isAfterDayTime = useMemo(
+    () => currentTime.isAfter(dayjs(times.sunset)),
     [currentTime, times]
   );
 
@@ -70,11 +83,13 @@ export const useSiteTime = (
   return {
     currentTime,
     isDayTime,
+    isAfterDayTime,
     timeFormat,
     dayFormat,
     weekdayFormat,
     timezone,
     ...times,
+    tomorrowTimes,
   };
 };
 

--- a/lib/time.ts
+++ b/lib/time.ts
@@ -30,10 +30,9 @@ export const useSiteTime = (
   );
 
   const [currentTime, setCurrentTime] = useState(dayjs().tz(timezone));
-  const [tomorrow, setTomorrow] = useState(currentTime.add(1, 'day'));
+  const tomorrow = currentTime.add(1, 'day');
 
   useEffect(() => setCurrentTime(dayjs().tz(timezone)), [timezone]);
-  useEffect(() => setTomorrow(currentTime.add(1, 'day')), [currentTime]);
 
   useEffect(() => {
     if (updateEnabled) {


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: 🚀

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Currently, our threshold graph is only displaying tomorrow's forecast after midnight. We want it to start displaying tomorrow's forecast after sunset today.

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #259

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
