### PR TITLE
Add help center for mobile screen

### DIFF
--- a/lib/components/navigation/BottomNavBar.tsx
+++ b/lib/components/navigation/BottomNavBar.tsx
@@ -4,7 +4,7 @@ import {
   ChartBarIcon,
   ChevronLeftIcon,
   ListBulletIcon,
-  MagnifyingGlassIcon,
+  QuestionMarkCircleIcon,
 } from '@heroicons/react/24/solid';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useRouter } from 'next/router';
@@ -23,9 +23,9 @@ const defaultIcons = [
     link: '/sites',
   },
   {
-    title: 'More Info',
-    icon: MagnifyingGlassIcon,
-    link: '/more-info',
+    title: 'Help Center',
+    icon: QuestionMarkCircleIcon,
+    link: '/help-center',
   },
 ];
 

--- a/lib/components/navigation/FAQLink.tsx
+++ b/lib/components/navigation/FAQLink.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+type FAQLinkProps = {
+  title: string;
+  href: string;
+};
+
+const FAQLink: React.FC<FAQLinkProps> = ({ title, href }) => {
+  return (
+    <Link href={href} passHref>
+      <a className="my-5 flex h-fit justify-center rounded-lg border-[2px] border-ocf-black-500 bg-ocf-black-500 p-5 text-center hover:border-ocf-yellow md:text-left">
+        <div className="justify-center">
+          <div className="text-base font-semibold leading-none text-ocf-gray">
+            {title}
+          </div>
+        </div>
+      </a>
+    </Link>
+  );
+};
+
+export default FAQLink;

--- a/lib/components/navigation/FAQLink.tsx
+++ b/lib/components/navigation/FAQLink.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-type FAQLinkProps = {
+type HelpCenterLinkProps = {
   title: string;
   href: string;
 };

--- a/lib/components/navigation/FAQLink.tsx
+++ b/lib/components/navigation/FAQLink.tsx
@@ -5,7 +5,7 @@ type HelpCenterLinkProps = {
   href: string;
 };
 
-const HelpCenterLink: React.FC<FAQLinkProps> = ({ title, href }) => {
+const HelpCenterLink: React.FC<HelpCenterLinkProps> = ({ title, href }) => {
   return (
     <Link href={href} passHref>
       <a className="my-5 flex h-fit justify-center rounded-lg border-[2px] border-ocf-black-500 bg-ocf-black-500 p-5 text-center hover:border-ocf-yellow md:text-left">
@@ -19,4 +19,4 @@ const HelpCenterLink: React.FC<FAQLinkProps> = ({ title, href }) => {
   );
 };
 
-export default FAQLink;
+export default HelpCenterLink;

--- a/lib/components/navigation/FAQLink.tsx
+++ b/lib/components/navigation/FAQLink.tsx
@@ -5,7 +5,7 @@ type HelpCenterLinkProps = {
   href: string;
 };
 
-const FAQLink: React.FC<FAQLinkProps> = ({ title, href }) => {
+const HelpCenterLink: React.FC<FAQLinkProps> = ({ title, href }) => {
   return (
     <Link href={href} passHref>
       <a className="my-5 flex h-fit justify-center rounded-lg border-[2px] border-ocf-black-500 bg-ocf-black-500 p-5 text-center hover:border-ocf-yellow md:text-left">

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -97,7 +97,7 @@ export function useClickedOutside(ref: RefObject<any>, handler: () => void) {
  * Turns URL into capitalized title
  * @param page page url to convert to title
  */
-export const urlToDisplay = (page: string) => {
+export const hyphensToTitleCase = (page: string) => {
   return page
     .split('-')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -92,3 +92,14 @@ export function useClickedOutside(ref: RefObject<any>, handler: () => void) {
     return () => document.removeEventListener('click', handleClickOutside);
   }, [ref, handler]);
 }
+
+/**
+ * Turns URL into capitalized title
+ * @param page page url to convert to title
+ */
+export const urlToDisplay = (page: string) => {
+  return page
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};

--- a/pages/help-center.tsx
+++ b/pages/help-center.tsx
@@ -4,13 +4,19 @@ import 'react-responsive-carousel/lib/styles/carousel.min.css';
 import Image from 'next/image';
 import { withSites } from '~/lib/sites';
 import { appliances } from '~/lib/appliances';
+import FAQLink from '~/lib/components/navigation/FAQLink';
+import { pages } from './help/[page]';
+import { urlToDisplay } from '~/lib/utils';
 
 const MoreInfo = () => {
   const sortedAppliances = appliances.sort((a, b) => b.kW - a.kW);
 
   return (
     <div className="min-h-screen w-screen max-w-screen-lg bg-ocf-black px-4">
-      <h1 className="my-2 mt-4 text-3xl font-bold text-ocf-gray">More Info</h1>
+      <h1 className="my-4 text-3xl font-bold text-ocf-gray">Help Center</h1>
+      <h2 className="my-6 text-base font-semibold leading-none text-ocf-gray">
+        Energy usage by appliance
+      </h2>
       <div className="rounded-lg bg-ocf-black-500">
         <Carousel
           showStatus={false}
@@ -66,6 +72,20 @@ const MoreInfo = () => {
             <PowerInfoCard key={element.name} {...element} />
           ))}
         </Carousel>
+      </div>
+      <h2 className="my-6 text-base font-semibold leading-none text-ocf-gray">
+        FAQs
+      </h2>
+      <div>
+        {Object.keys(pages).map((page) => {
+          return (
+            <FAQLink
+              key={page}
+              title={urlToDisplay(page)}
+              href={`/help/${page}`}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/pages/help-center.tsx
+++ b/pages/help-center.tsx
@@ -6,7 +6,7 @@ import { withSites } from '~/lib/sites';
 import { appliances } from '~/lib/appliances';
 import FAQLink from '~/lib/components/navigation/FAQLink';
 import { pages } from './help/[page]';
-import { urlToDisplay } from '~/lib/utils';
+import { hyphensToTitleCase } from '~/lib/utils';
 
 const MoreInfo = () => {
   const sortedAppliances = appliances.sort((a, b) => b.kW - a.kW);
@@ -81,7 +81,7 @@ const MoreInfo = () => {
           return (
             <FAQLink
               key={page}
-              title={urlToDisplay(page)}
+              title={hyphensToTitleCase(page)}
               href={`/help/${page}`}
             />
           );

--- a/pages/help-center.tsx
+++ b/pages/help-center.tsx
@@ -74,7 +74,7 @@ const MoreInfo = () => {
         </Carousel>
       </div>
       <h2 className="my-6 text-base font-semibold leading-none text-ocf-gray">
-        FAQs
+        Help Topics
       </h2>
       <div>
         {Object.keys(pages).map((page) => {

--- a/pages/help/[page].tsx
+++ b/pages/help/[page].tsx
@@ -8,9 +8,9 @@ import { LinkProps } from 'next/link';
 import { urlToDisplay } from '~/lib/utils';
 
 export const pages = {
-  'add-site-location': addSiteLocation,
-  'enter-site-details': enterSiteDetails,
-  'handle-split-sites': handleSplitSites,
+  'adding-site-locations': addSiteLocation,
+  'entering-site-details': enterSiteDetails,
+  'handling-split-sites': handleSplitSites,
 } as const;
 
 type MenuLinkProps = {

--- a/pages/help/[page].tsx
+++ b/pages/help/[page].tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { LinkProps } from 'next/link';
-import { urlToDisplay } from '~/lib/utils';
+import { hyphensToTitleCase } from '~/lib/utils';
 
 export const pages = {
   'adding-site-locations': addSiteLocation,
@@ -58,7 +58,7 @@ const Help = () => {
               <MenuLink
                 key={page}
                 linkProps={{ href: `/help/${page}` }}
-                label={urlToDisplay(page)}
+                label={hyphensToTitleCase(page)}
                 currentPath={router.asPath}
               />
             );

--- a/pages/help/[page].tsx
+++ b/pages/help/[page].tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { LinkProps } from 'next/link';
+import { urlToDisplay } from '~/lib/utils';
 
 export const pages = {
   'add-site-location': addSiteLocation,
@@ -16,13 +17,6 @@ type MenuLinkProps = {
   linkProps: LinkProps;
   label: string;
   currentPath: string;
-};
-
-const urlToDisplay = (page: string) => {
-  return page
-    .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
 };
 
 const MenuLink: React.FC<MenuLinkProps> = ({


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
* Add help center page for mobile screen
* Has information cards that link to pages that already exist in the desktop view
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #253 

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots
![image](https://user-images.githubusercontent.com/49364484/235328453-0114dcd8-e921-42ee-9927-625d473ae629.png)

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
