### PR TITLE
Geocoder in map and UI fixes 

### DIFF
--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -19,9 +19,9 @@ const Button: FC<PropsWithChildren<Props>> = ({
   variant = 'solid',
   onClick,
 }) => {
-  const buttonClass = `h-[50px] h-[50px] w-[200px] md:text-base text-xl transition-all duration-300 rounded-md md:font-semibold font-bold `;
+  const buttonClass = `inline-flex gap-[10px] items-center justify-center text-center h-[50px] h-[50px] w-[200px] md:text-base text-xl transition-all duration-300 rounded-md md:font-semibold font-bold `;
   const outlinedButton = `text-ocf-yellow border-ocf-yellow border-[2px] hover:bg-ocf-yellow hover:text-black`;
-  const solidButton = `bg-ocf-yellow text-black disabled:bg-ocf-gray disabled:text-ocf-black-600 max-w-sm`;
+  const solidButton = `bg-ocf-yellow text-black disabled:bg-ocf-gray disabled:text-ocf-black-600`;
 
   return (
     <button

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -1,11 +1,11 @@
 import { FC, PropsWithChildren } from 'react';
+import { overrideTailwindClasses } from 'tailwind-override';
 
 interface Props {
   form?: string;
   disabled?: boolean;
   hidden?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
   className?: string;
-  width?: string | number;
   variant: 'solid' | 'outlined';
   onClick?: () => void;
 }
@@ -17,22 +17,22 @@ const Button: FC<PropsWithChildren<Props>> = ({
   hidden,
   className = '',
   variant = 'solid',
-  width = '200px',
   onClick,
 }) => {
-  const outlinedButton = `h-[54px] w-[${width}] text-xl text-ocf-yellow border-ocf-yellow border-[2px] rounded-md font-semibold hover:bg-ocf-yellow hover:text-black transition-all duration-300`;
+  const buttonClass = `h-[54px] h-[54px] w-[200px] md:text-lg text-xl transition-all duration-300`;
+  const outlinedButton = `  text-ocf-yellow border-ocf-yellow border-[2px] rounded-md md:font-semibold font-bold hover:bg-ocf-yellow hover:text-black`;
+  const solidButton = ` bg-ocf-yellow text-black disabled:bg-ocf-gray disabled:text-ocf-black-600 shadow h-14 max-w-sm text-center rounded-md md:rounded-lg md:font-semibold font-bold`;
 
-  const solidButton = `inline-flex gap-[10px] items-center justify-center w-[${width}] bg-ocf-yellow text-black disabled:bg-ocf-gray disabled:text-ocf-black-600 transition-all duration-300 shadow h-14 max-w-sm text-center rounded-md md:rounded-lg md:font-semibold font-bold text-xl`;
-
+  
   return (
     <button
       suppressHydrationWarning
       form={form}
       onClick={onClick}
       disabled={disabled}
-      className={`${variant === 'solid' ? solidButton : outlinedButton} ${
-        hidden && `${hidden}:hidden`
-      } ${className}`}
+      className={overrideTailwindClasses(`${buttonClass} ${
+        variant === 'solid' ? solidButton : outlinedButton
+      }  ${className}  ${hidden && `${hidden}:hidden`}`)}
     >
       {children}
     </button>

--- a/lib/components/Button.tsx
+++ b/lib/components/Button.tsx
@@ -19,20 +19,21 @@ const Button: FC<PropsWithChildren<Props>> = ({
   variant = 'solid',
   onClick,
 }) => {
-  const buttonClass = `h-[54px] h-[54px] w-[200px] md:text-lg text-xl transition-all duration-300`;
-  const outlinedButton = `  text-ocf-yellow border-ocf-yellow border-[2px] rounded-md md:font-semibold font-bold hover:bg-ocf-yellow hover:text-black`;
-  const solidButton = ` bg-ocf-yellow text-black disabled:bg-ocf-gray disabled:text-ocf-black-600 shadow h-14 max-w-sm text-center rounded-md md:rounded-lg md:font-semibold font-bold`;
+  const buttonClass = `h-[50px] h-[50px] w-[200px] md:text-base text-xl transition-all duration-300 rounded-md md:font-semibold font-bold `;
+  const outlinedButton = `text-ocf-yellow border-ocf-yellow border-[2px] hover:bg-ocf-yellow hover:text-black`;
+  const solidButton = `bg-ocf-yellow text-black disabled:bg-ocf-gray disabled:text-ocf-black-600 max-w-sm`;
 
-  
   return (
     <button
       suppressHydrationWarning
       form={form}
       onClick={onClick}
       disabled={disabled}
-      className={overrideTailwindClasses(`${buttonClass} ${
-        variant === 'solid' ? solidButton : outlinedButton
-      }  ${className}  ${hidden && `${hidden}:hidden`}`)}
+      className={overrideTailwindClasses(
+        `${buttonClass} ${
+          variant === 'solid' ? solidButton : outlinedButton
+        }  ${className}  ${hidden && `${hidden}:hidden`}`
+      )}
     >
       {children}
     </button>

--- a/lib/components/Dashboard.tsx
+++ b/lib/components/Dashboard.tsx
@@ -18,7 +18,7 @@ const Dashboard: FC<DashboardProps> = ({ sites }) => {
   return (
     <div className="mb-[var(--bottom-nav-margin)] w-screen max-w-screen-lg bg-ocf-black px-4">
       <div className="flex flex-row items-center justify-between">
-        <h1 className="mb-4 mt-4 text-3xl font-bold text-ocf-gray">
+        <h1 className="mb-4 mt-4 text-xl font-semibold text-ocf-gray md:text-2xl">
           {isAggregate ? 'Dashboard' : sites[0].client_site_name}
         </h1>
         <div className="block md:hidden">

--- a/lib/components/form/Details.tsx
+++ b/lib/components/form/Details.tsx
@@ -69,9 +69,9 @@ const Details: FC<Props> = ({
 
   return (
     <div className="mb-[max(var(--bottom-nav-margin),20px)] flex flex-col gap-10">
-      <div className="flex w-4/5 flex-row self-center md:w-8/12">
-        <div className="hidden flex-1 flex-col pr-8 md:flex">
-          <h1 className="mt-2 text-2xl font-semibold dark:text-ocf-gray md:text-2xl">
+      <div className="flex w-5/6 max-w-sm flex-row self-center lg:w-8/12 lg:max-w-full">
+        <div className="hidden flex-1 flex-col pr-8 lg:flex">
+          <h1 className="mb-6 mt-2 text-xl text-xl font-semibold dark:text-ocf-gray">
             Your site&apos;s details
           </h1>
           <div className="w-full flex-1" onClick={mapButtonCallback}>
@@ -88,7 +88,7 @@ const Details: FC<Props> = ({
           </div>
           <button
             onClick={lastPageCallback}
-            className="mb-2 mr-2 mt-8 inline-flex h-14 items-center justify-center rounded-md border-gray-200 bg-ocf-yellow px-5 py-2.5 text-center text-xl font-bold shadow transition duration-150 focus:outline-none focus:ring-4 focus:ring-gray-100 peer-invalid:bg-ocf-gray-300 dark:bg-ocf-yellow dark:disabled:bg-ocf-gray-300 md:hidden"
+            className="mb-2 mr-2 mt-8 inline-flex h-14 items-center justify-center rounded-md border-gray-200 bg-ocf-yellow px-5 py-2.5 text-center text-xl font-bold shadow transition duration-150 focus:outline-none focus:ring-4 focus:ring-gray-100 peer-invalid:bg-ocf-gray-300 dark:bg-ocf-yellow dark:disabled:bg-ocf-gray-300 lg:hidden"
           >
             {isEditing ? 'Exit' : 'Back'}
           </button>
@@ -96,7 +96,7 @@ const Details: FC<Props> = ({
         <form id="panel-form" className="flex-1" onSubmit={onSubmit}>
           {isEditing && (
             <div
-              className="flex flex-col md:hidden"
+              className="flex flex-col lg:hidden"
               onClick={mapButtonCallback}
             >
               <label className="mt-8 block pb-1 text-lg font-[600] text-ocf-gray short:mt-4">
@@ -114,7 +114,7 @@ const Details: FC<Props> = ({
               />
             </div>
           )}
-          <div className="hidden md:block md:h-7" />
+          <div className="hidden lg:block lg:h-7" />
           <Input
             id="site-name"
             label="Site name"
@@ -232,7 +232,7 @@ const Details: FC<Props> = ({
           />
           <button
             disabled={didSubmit || (isEditing && !edited)}
-            className="mb-2 mr-2 mt-8 inline-flex h-14 w-full items-center justify-center rounded-md border-gray-200 bg-ocf-yellow px-5 py-2.5 text-center text-xl font-bold shadow transition duration-150 focus:outline-none focus:ring-4 focus:ring-gray-100 peer-invalid:bg-ocf-gray-300 dark:bg-ocf-yellow dark:disabled:bg-ocf-gray-300 md:hidden"
+            className="mb-2 mr-2 mt-8 inline-flex h-14 w-full items-center justify-center rounded-md border-gray-200 bg-ocf-yellow px-5 py-2.5 text-center text-xl font-bold shadow transition duration-150 focus:outline-none focus:ring-4 focus:ring-gray-100 peer-invalid:bg-ocf-gray-300 dark:bg-ocf-yellow dark:disabled:bg-ocf-gray-300 lg:hidden"
           >
             {(didSubmit || showSuccessIcon) && (
               <div className="mx-2 h-5 w-5 overflow-hidden">
@@ -242,13 +242,13 @@ const Details: FC<Props> = ({
                 )}
               </div>
             )}
-            {isEditing ? 'Save Changes' : 'Finish'}
+            {isEditing ? 'Save Changes' : 'Next'}
             {(didSubmit || showSuccessIcon) && <div className="mx-2 w-5" />}
           </button>
         </form>
       </div>
       <Modal open={modalOpen} onOpen={setModalOpen} />
-      <div className="mx-auto mt-auto hidden w-10/12 md:flex md:flex-row md:justify-between">
+      <div className="mx-auto mt-auto hidden w-10/12 lg:flex lg:flex-row lg:justify-between">
         <Button
           form="panel-form"
           onClick={lastPageCallback}
@@ -272,7 +272,7 @@ const Details: FC<Props> = ({
               )}
             </div>
           )}
-          {isEditing ? 'Save' : 'Finish'}
+          {isEditing ? 'Save' : 'Next'}
           {(didSubmit || showSuccessIcon) && <div className="mx-2 w-5" />}
         </Button>
       </div>

--- a/lib/components/form/Details.tsx
+++ b/lib/components/form/Details.tsx
@@ -249,7 +249,12 @@ const Details: FC<Props> = ({
       </div>
       <Modal open={modalOpen} onOpen={setModalOpen} />
       <div className="mx-auto mt-auto hidden w-10/12 md:flex md:flex-row md:justify-between">
-        <Button form="panel-form" onClick={lastPageCallback} variant="outlined">
+        <Button
+          form="panel-form"
+          onClick={lastPageCallback}
+          variant="outlined"
+          className="w-[100px]"
+        >
           {isEditing ? 'Exit' : 'Back'}
         </Button>
 
@@ -257,7 +262,7 @@ const Details: FC<Props> = ({
           form="panel-form"
           disabled={didSubmit || (isEditing && !edited)}
           variant="solid"
-          className={isEditing ? 'w-[250px]' : 'w-[200px]'}
+          className="w-[100px]"
         >
           {(didSubmit || showSuccessIcon) && (
             <div className="mx-2 h-5 w-5 overflow-hidden">
@@ -267,7 +272,7 @@ const Details: FC<Props> = ({
               )}
             </div>
           )}
-          {isEditing ? 'Save Changes' : 'Finish'}
+          {isEditing ? 'Save' : 'Finish'}
           {(didSubmit || showSuccessIcon) && <div className="mx-2 w-5" />}
         </Button>
       </div>

--- a/lib/components/form/Input.tsx
+++ b/lib/components/form/Input.tsx
@@ -24,7 +24,7 @@ const Input: FC<InputProps> = ({
   return (
     <>
       <label
-        className="mt-8 block pb-1 text-lg font-[500] dark:text-ocf-gray short:mt-4"
+        className="text-md mt-4 block pb-1 font-[500] dark:text-ocf-gray"
         htmlFor={id}
       >
         {label}

--- a/lib/components/form/Location.tsx
+++ b/lib/components/form/Location.tsx
@@ -65,7 +65,7 @@ const Location: FC<Props> = ({
                 form="panel-form"
                 onClick={lastPageCallback}
                 variant="outlined"
-                className="w-[250px]"
+                className="w-[100px]"
               >
                 Back
               </Button>
@@ -75,9 +75,9 @@ const Location: FC<Props> = ({
             disabled={!isSubmissionEnabled}
             onClick={nextPageCallback}
             variant="solid"
-            className="w-full md:w-[250px]"
+            className="w-full md:w-[100px]"
           >
-            {isEditing ? 'Continue' : 'Next'}
+            Next
           </Button>
         </div>
       </div>

--- a/lib/components/form/Location.tsx
+++ b/lib/components/form/Location.tsx
@@ -36,7 +36,7 @@ const Location: FC<Props> = ({
           className="mb-3 flex w-[95%] max-w-md flex-1 flex-col self-center lg:h-full lg:w-1/2 lg:min-w-[750px] lg:max-w-full"
           id="mapboxInputWrapper"
         >
-          <h1 className="text-xl font-semibold text-ocf-gray lg:mb-5 lg:mt-7 lg:text-xl">
+          <h1 className="mb-3 text-xl font-semibold text-ocf-gray lg:mb-5 lg:mt-7 lg:text-xl">
             Where is your solar panel located?
           </h1>
           <div className="flex-1">

--- a/lib/components/form/Location.tsx
+++ b/lib/components/form/Location.tsx
@@ -22,21 +22,21 @@ const Location: FC<Props> = ({
 }) => {
   const [isSubmissionEnabled, setIsSubmissionEnabled] = useState(false);
 
-  // The map should zopm into the initial coordinates if they were entered by the user
+  // The map should zoom into the initial coordinates if they were entered by the user
   const shouldZoomIntoOriginal =
     originalLat !== formData.latitude || originalLng !== formData.longitude;
 
   return (
     <>
       <div
-        className="bg-mapbox-gray-1000 relative flex h-[calc(100vh-var(--nav-height))] w-screen flex-col justify-between gap-2 py-4 md:h-[85vh] md:py-0"
+        className="bg-mapbox-gray-1000 relative flex h-[calc(100vh-var(--nav-height))] w-screen flex-col justify-between gap-2 py-4 lg:h-[85vh] lg:py-0"
         id="rootDiv"
       >
         <div
-          className="mb-3 flex w-[95%] flex-1 flex-col self-center md:h-full md:w-1/2 md:min-w-[750px]"
+          className="mb-3 flex w-[95%] max-w-md flex-1 flex-col self-center lg:h-full lg:w-1/2 lg:min-w-[750px] lg:max-w-full"
           id="mapboxInputWrapper"
         >
-          <h1 className="text-xl font-semibold text-ocf-gray md:mt-7 md:text-2xl">
+          <h1 className="text-xl font-semibold text-ocf-gray lg:mb-5 lg:mt-7 lg:text-xl">
             Where is your solar panel located?
           </h1>
           <div className="flex-1">
@@ -58,8 +58,8 @@ const Location: FC<Props> = ({
             />
           </div>
         </div>
-        <div className="mb-3 mt-3 flex items-center justify-center md:mx-auto md:mb-8 md:mt-auto md:w-10/12 md:justify-between">
-          <div className="hidden md:block">
+        <div className="mb-3 mt-3 flex items-center justify-center lg:mx-auto lg:mb-8 lg:mt-auto lg:w-10/12 lg:justify-between">
+          <div className="hidden lg:block">
             {!isEditing && (
               <Button
                 form="panel-form"
@@ -75,7 +75,7 @@ const Location: FC<Props> = ({
             disabled={!isSubmissionEnabled}
             onClick={nextPageCallback}
             variant="solid"
-            className="w-full md:w-[100px]"
+            className="w-11/12 max-w-md lg:w-[100px]"
           >
             Next
           </Button>

--- a/lib/components/form/LocationInput.tsx
+++ b/lib/components/form/LocationInput.tsx
@@ -58,7 +58,8 @@ const LocationInput: FC<LocationInputProps> = ({
           positionOptions: {
             enableHighAccuracy: true,
           },
-        })
+        }),
+        'bottom-right'
       );
     }
 
@@ -86,7 +87,8 @@ const LocationInput: FC<LocationInputProps> = ({
       limit: 3,
     });
 
-    geocoderContainer.current?.appendChild(geocoder.onAdd(map.current!));
+    // geocoderContainer.current?.appendChild(geocoder.onAdd(map.current!));
+    map.current.addControl(geocoder, 'top-left');
 
     if (!canEdit) {
       // Prevent user from changing the geocoder input when the map isn't editable
@@ -268,7 +270,7 @@ const LocationInput: FC<LocationInputProps> = ({
       <div className="relative top-0 flex flex-1 flex-col">
         <div
           ref={mapContainer}
-          className="h-full rounded-3xl"
+          className="h-full rounded-xl"
           id="mapContainer"
         />
       </div>

--- a/lib/components/form/ViewInverters.tsx
+++ b/lib/components/form/ViewInverters.tsx
@@ -95,7 +95,7 @@ const ViewInverters: FC<ViewInvertersProps> = ({
     </div>
   ) : (
     <div className="flex h-[var(--onboarding-height)] w-full flex-col items-center">
-      <div className="flex h-full w-4/5 flex-col justify-between md:w-8/12">
+      <div className="flex h-full w-4/5 flex-1 flex-col justify-between md:w-8/12">
         {isEditMode && (
           <div className="flex w-full">
             <NavbarLink title="Details" href={`/site-details/${siteUUID}`} />
@@ -159,7 +159,7 @@ const ViewInverters: FC<ViewInvertersProps> = ({
           </Button>
         </div>
       </div>
-      <div className="mt-auto hidden w-full justify-between pb-24 md:flex md:w-8/12 md:flex-row">
+      <div className="mt-auto hidden w-full justify-between pb-24 md:flex md:w-10/12 md:flex-row">
         {backButton ? (
           <Button
             onClick={lastPageCallback}

--- a/lib/components/form/ViewInverters.tsx
+++ b/lib/components/form/ViewInverters.tsx
@@ -86,7 +86,7 @@ const ViewInverters: FC<ViewInvertersProps> = ({
     ? 'Select Inverters'
     : 'Connected Inverters';
   const defaultButtonText = isSelectMode ? 'Submit' : 'Next';
-  const editModeButtonText = 'Save Changes';
+  const editModeButtonText = 'Save';
 
   // @TODO skeletons!!
   return isLoading ? (
@@ -164,7 +164,7 @@ const ViewInverters: FC<ViewInvertersProps> = ({
           <Button
             onClick={lastPageCallback}
             variant="outlined"
-            className="w-[250px]"
+            className="w-[100px]"
           >
             {isEditMode ? 'Exit' : 'Back'}
           </Button>
@@ -175,7 +175,7 @@ const ViewInverters: FC<ViewInvertersProps> = ({
           variant="solid"
           disabled={(isSelectMode && selectedInverters.length < 1) || didSubmit}
           onClick={isEditMode ? submit : nextPageOrSubmit}
-          className="w-[250px]"
+          className="w-[100px]"
         >
           {(didSubmit || showSuccessIcon) && (
             <div className="mx-2 h-5 w-5 overflow-hidden">

--- a/lib/components/graphs/Graph.tsx
+++ b/lib/components/graphs/Graph.tsx
@@ -17,6 +17,8 @@ import { useSiteAggregation } from '~/lib/sites';
 import { useSiteTime } from '~/lib/time';
 import { GenerationDataPoint, Site } from '~/lib/types';
 import TimeRangeInput from './TimeRangeInput';
+import { useIsMobile, useMediaQuery } from '~/lib/utils';
+import { overrideTailwindClasses } from 'tailwind-override';
 
 const graphPriorPercentage = 1 / 8;
 function getGraphStartDate(currentDate: Date, totalHours: number) {
@@ -73,6 +75,9 @@ const Graph: FC<GraphProps> = ({ sites }) => {
   const { currentTime, weekdayFormat } = useSiteTime(representativeSite, {
     updateEnabled: timeEnabled,
   });
+
+  const isMobile = useIsMobile();
+  const isExtraSmallMobile = useMediaQuery('(max-width: 390px)');
 
   const [timeRange, setTimeRange] = useState(48);
 
@@ -161,39 +166,51 @@ const Graph: FC<GraphProps> = ({ sites }) => {
   };
 
   return (
-    <div className="h-[260px] w-full rounded-2xl bg-ocf-black-500 p-3">
-      <div className="ml-1 flex gap-2">
-        <TimeRangeInput
-          label="6H"
-          value={6}
-          checked={timeRange === 6}
-          onChange={handleChange}
-        />
-        <TimeRangeInput
-          label="1D"
-          value={24}
-          checked={timeRange === 24}
-          onChange={handleChange}
-        />
-        <TimeRangeInput
-          label="2D"
-          value={48}
-          checked={timeRange === 48}
-          onChange={handleChange}
-        />
-      </div>
-      <div className="ml-[9%] mt-[20px] flex  gap-3 text-sm">
-        <div className="flex">
-          <LegendLineGraphIcon className="text-ocf-yellow-500" />
-          <p className="ml-[5px] mt-[2px] text-white">OCF Final Forecast</p>
+    <div className="h-[220px] w-full rounded-2xl bg-ocf-black-500 p-3">
+      <div className="mt-2 flex w-full flex-row justify-between px-2 sm:px-6">
+        <div className="flex gap-2">
+          <TimeRangeInput
+            label="6H"
+            value={6}
+            checked={timeRange === 6}
+            onChange={handleChange}
+          />
+          <TimeRangeInput
+            label="1D"
+            value={24}
+            checked={timeRange === 24}
+            onChange={handleChange}
+          />
+          <TimeRangeInput
+            label="2D"
+            value={48}
+            checked={timeRange === 48}
+            onChange={handleChange}
+          />
         </div>
-        <div className="flex">
-          <LegendLineGraphIcon className="text-ocf-blue" />
-          <p className="ml-[5px] mt-[2px] text-white">Clear Sky</p>
-        </div>
-        <div className="flex">
-          <LegendLineGraphIcon className="text-white" />
-          <p className="ml-[5px] mt-[2px] text-white">Actual Output</p>
+        <div
+          className={overrideTailwindClasses(
+            `flex flex-wrap justify-end gap-1 text-xs sm:gap-3 ${
+              isExtraSmallMobile && 'text-[9px]'
+            } md:text-sm`
+          )}
+        >
+          <div className="flex">
+            <LegendLineGraphIcon className="text-ocf-yellow-500" />
+            <p className="ml-[5px] mt-[2px] text-white">Forecast</p>
+          </div>
+          <div className="flex">
+            <LegendLineGraphIcon className="text-ocf-blue" />
+            <p className="ml-[5px] mt-[2px] text-white">
+              {isExtraSmallMobile ? 'Clear' : 'Clear Sky'}
+            </p>
+          </div>
+          <div className="flex">
+            <LegendLineGraphIcon className="text-white" />
+            <p className="ml-[5px] mt-[2px] text-white">
+              {isMobile ? 'Actual' : 'Actual Output'}
+            </p>
+          </div>
         </div>
       </div>
       {!isLoading && (

--- a/lib/components/navigation/SideBar.tsx
+++ b/lib/components/navigation/SideBar.tsx
@@ -90,7 +90,7 @@ const SideBar: FC<SideBarProps> = ({ open, onClose }) => {
     <div
       className={`fixed top-0 z-50 h-full transition-all duration-500 ${
         open
-          ? 'translate-x-0 shadow-side-bar shadow-ocf-black'
+          ? 'translate-x-0 border-r-[0.5px] border-white'
           : '-translate-x-[100%]'
       }`}
       // @ts-ignore

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-responsive-carousel": "^3.2.23",
     "recharts": "^2.4.3",
     "suncalc": "^1.9.0",
-    "swr": "^2.0.3"
+    "swr": "^2.0.3",
+    "tailwind-override": "^0.6.1"
   },
   "devDependencies": {
     "@savvywombat/tailwindcss-grid-areas": "^3.0.1",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -29,6 +29,15 @@
   @apply my-3 h-14 min-w-full bg-ocf-black md:my-5;
 }
 
+/* Apply styles to geocoder position in map */
+.mapboxgl-ctrl-top-left {
+  @apply w-full px-2 pt-2 md:px-5 md:pt-5;
+}
+
+.mapboxgl-ctrl-top-left .mapboxgl-ctrl {
+  @apply m-0 !important;
+}
+
 /* Apply styles to #map */
 #map {
   @apply mt-8;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,7 +26,7 @@
 
 /* Apply additional styles to .mapboxgl-ctrl-geocoder */
 .mapboxgl-ctrl-geocoder {
-  @apply my-3 h-14 min-w-full bg-ocf-black md:my-5;
+  @apply h-14 min-w-full bg-ocf-black !important;
 }
 
 /* Apply styles to geocoder position in map */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3955,6 +3955,11 @@ synckit@^0.8.5:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
+tailwind-override@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/tailwind-override/-/tailwind-override-0.6.1.tgz#6a672d96fb2b8756aba739796d2b0c5046765e73"
+  integrity sha512-FOxLFcXTe9eqC85SNCREyWw/CG8hyNSBJNrp+rjMDV7m63UoJzpkNJtXNrA0y3tE9m0d3ccNj8HBVQG/hfmNxA==
+
 tailwindcss@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.1.tgz#b6662fab6a9b704779e48d083a9fef5a81d2b81e"


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: :rocket: Ready

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #296. Adds `tailwind-override` package in order to allow for consistent application of custom classnames in button component. Also changes geocoding input to be within the map rather than outside. Also, 
- refactors classnames in button component
- changes width and spacing of buttons in form submission and edit flow 
- changes legend positioning on graph 
- changes a few font sizes and weights, mostly in headers 

## Screenshots
<img width="1353" alt="Screenshot 2023-05-18 at 1 23 30 AM" src="https://github.com/openclimatefix/pv-sites-mobile/assets/62641231/c232f795-08b0-4b85-9b8e-d82f92488f32">
<img width="1160" alt="Screenshot 2023-05-18 at 1 24 12 AM" src="https://github.com/openclimatefix/pv-sites-mobile/assets/62641231/3bc633f8-969b-422f-9697-2ab9cd7b8d3d">
<img width="376" alt="Screenshot 2023-05-18 at 1 36 04 AM" src="https://github.com/openclimatefix/pv-sites-mobile/assets/62641231/261d44e3-84bd-4d7c-8c6e-f5e280b80f81">

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
