### PR TITLE
More small UI fixes

### DIFF
--- a/content/help/add-site-location.md
+++ b/content/help/add-site-location.md
@@ -1,6 +1,6 @@
 # Adding a Site for Solar Energy Forecasting
 
-Adding a site for solar energy forecasting is a crucial step in using our web app to generate accurate and relevant forecast data. However, we understand that this can sometimes be a challenging process. Here are some common issues users may encounter when adding a site, and tips for how to overcome them:
+Adding a site for solar energy forecasting is a crucial step in using our web app to generate accurate and relevant forecast data. Here are some common issues you may encounter when adding a site, and tips for how to overcome them:
 
 ## Using the Interactive Map
 
@@ -14,7 +14,7 @@ Our interactive map is the primary tool for adding a site and specifying its exa
 
 ## Troubleshooting
 
-Here are some common issues users may encounter when trying to add a site, and tips for how to overcome them:
+Here are some common issues you may encounter when trying to add a site, and tips for how to overcome them:
 
 - The location pin won't move: If you're having trouble moving the location pin, make sure you're zoomed in enough on the map. The pin won't move if you're zoomed out too far.
 

--- a/lib/components/Dashboard.tsx
+++ b/lib/components/Dashboard.tsx
@@ -8,12 +8,15 @@ import Graph from './graphs/Graph';
 import CurrentOutput from './dashboard-modules/CurrentOutput';
 import { Site } from '~/lib/types';
 import ContactButton from './ContactButton';
+import { useMediaQuery } from '../utils';
 
 interface DashboardProps {
   sites: Site[];
 }
 const Dashboard: FC<DashboardProps> = ({ sites }) => {
   const isAggregate = sites.length > 1;
+
+  const isExtraSmall = useMediaQuery('(max-width: 400px)');
 
   return (
     <div className="mb-[var(--bottom-nav-margin)] w-screen max-w-screen-lg bg-ocf-black px-4">
@@ -26,7 +29,13 @@ const Dashboard: FC<DashboardProps> = ({ sites }) => {
         </div>
       </div>
       <hr className="mx-[-100px] h-[1px] w-[500%] border-0 bg-ocf-black-500 md:hidden" />
-      <div className="grid w-full grid-cols-mobile-columns grid-rows-mobile-rows gap-4 grid-areas-dashboard-mobile md:grid-cols-desktop-columns md:grid-rows-desktop-rows md:grid-areas-dashboard-desktop">
+      <div
+        className={`grid w-full grid-cols-mobile-columns grid-rows-mobile-rows gap-4 ${
+          isExtraSmall
+            ? 'grid-areas-dashboard-mobile-xs'
+            : 'grid-areas-dashboard-mobile'
+        } md:grid-cols-desktop-columns md:grid-rows-desktop-rows md:grid-areas-dashboard-desktop`}
+      >
         <div className="block grid-in-Heading1 md:hidden">
           <h2 className="mt-2 text-base font-semibold leading-none text-ocf-gray">
             Solar Activity
@@ -46,7 +55,11 @@ const Dashboard: FC<DashboardProps> = ({ sites }) => {
             Metrics
           </h2>
         </div>
-        <div className="grid-in-Expected-Total-Output">
+        <div
+          className={`${
+            isExtraSmall ? 'hidden' : 'grid-in-Expected-Total-Output'
+          }`}
+        >
           <ExpectedTotalOutput sites={sites} />
         </div>
         <div className="grid-in-Current-Output md:hidden">

--- a/lib/components/Dashboard.tsx
+++ b/lib/components/Dashboard.tsx
@@ -16,8 +16,6 @@ interface DashboardProps {
 const Dashboard: FC<DashboardProps> = ({ sites }) => {
   const isAggregate = sites.length > 1;
 
-  const isExtraSmall = useMediaQuery('(max-width: 400px)');
-
   return (
     <div className="mb-[var(--bottom-nav-margin)] w-screen max-w-screen-lg bg-ocf-black px-4">
       <div className="flex flex-row items-center justify-between">
@@ -29,13 +27,7 @@ const Dashboard: FC<DashboardProps> = ({ sites }) => {
         </div>
       </div>
       <hr className="mx-[-100px] h-[1px] w-[500%] border-0 bg-ocf-black-500 md:hidden" />
-      <div
-        className={`grid w-full grid-cols-mobile-columns grid-rows-mobile-rows gap-4 ${
-          isExtraSmall
-            ? 'grid-areas-dashboard-mobile-xs'
-            : 'grid-areas-dashboard-mobile'
-        } md:grid-cols-desktop-columns md:grid-rows-desktop-rows md:grid-areas-dashboard-desktop`}
-      >
+      <div className="grid w-full grid-cols-mobile-columns grid-rows-mobile-rows gap-4 grid-areas-dashboard-mobile md:grid-cols-desktop-columns md:grid-rows-desktop-rows md:grid-areas-dashboard-desktop xm:grid-areas-dashboard-mobile-xs">
         <div className="block grid-in-Heading1 md:hidden">
           <h2 className="mt-2 text-base font-semibold leading-none text-ocf-gray">
             Solar Activity

--- a/lib/components/Dashboard.tsx
+++ b/lib/components/Dashboard.tsx
@@ -27,7 +27,7 @@ const Dashboard: FC<DashboardProps> = ({ sites }) => {
         </div>
       </div>
       <hr className="mx-[-100px] h-[1px] w-[500%] border-0 bg-ocf-black-500 md:hidden" />
-      <div className="grid w-full grid-cols-mobile-columns grid-rows-mobile-rows gap-4 grid-areas-dashboard-mobile md:grid-cols-desktop-columns md:grid-rows-desktop-rows md:grid-areas-dashboard-desktop xm:grid-areas-dashboard-mobile-xs">
+      <div className="grid w-full grid-cols-mobile-columns grid-rows-mobile-rows gap-4 grid-areas-dashboard-mobile md:grid-cols-desktop-columns md:grid-rows-desktop-rows md:grid-areas-dashboard-desktop xs:grid-areas-dashboard-mobile-xs">
         <div className="block grid-in-Heading1 md:hidden">
           <h2 className="mt-2 text-base font-semibold leading-none text-ocf-gray">
             Solar Activity
@@ -47,11 +47,7 @@ const Dashboard: FC<DashboardProps> = ({ sites }) => {
             Metrics
           </h2>
         </div>
-        <div
-          className={`${
-            isExtraSmall ? 'hidden' : 'grid-in-Expected-Total-Output'
-          }`}
-        >
+        <div className="grid-in-Expected-Total-Output xs:hidden">
           <ExpectedTotalOutput sites={sites} />
         </div>
         <div className="grid-in-Current-Output md:hidden">

--- a/lib/components/SiteCard.tsx
+++ b/lib/components/SiteCard.tsx
@@ -39,7 +39,7 @@ const SiteCard: FC<SiteCardProps> = ({ site, isEditMode }) => {
               !forecastData ? skeleton : ``
             }`}
           >
-            {forecastData ? 'Loading...' : site.client_site_name ?? 'My Site'}
+            {!forecastData ? 'Loading...' : site.client_site_name ?? 'My Site'}
           </h2>
           <div className="mt-2 flex flex-col gap-1">
             <p
@@ -76,7 +76,7 @@ const SiteCard: FC<SiteCardProps> = ({ site, isEditMode }) => {
 
         <div className={`pointer-events-none mr-5 w-[40%]`}>
           {/* TODO: find out why this left is necessary */}
-          {forecastData || !noError == undefined ? (
+          {!forecastData || !noError ? (
             <div className="h-[100px]"></div>
           ) : (
             <div className="relative -left-7">

--- a/lib/components/SiteCard.tsx
+++ b/lib/components/SiteCard.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { FC } from 'react';
+import React, { FC, PropsWithChildren } from 'react';
 import SiteGraph from './graphs/SiteGraph';
 import { DeleteIcon } from './icons';
 import { getCurrentTimeGeneration } from '../generation';
@@ -33,42 +33,42 @@ const SiteCard: FC<SiteCardProps> = ({ site, isEditMode }) => {
           isEditMode && 'pointer-events-none'
         }`}
       >
-        <div className="flex w-[60%] flex-1 flex-col p-4 pl-5">
+        <div className="flex w-[60%] flex-1 flex-col p-3 pl-5">
           <h2
-            className={`text-xl font-semibold text-amber transition-all ${
+            className={`text-lg font-semibold text-amber transition-all ${
               !forecastData ? skeleton : ``
             }`}
           >
             {!forecastData ? 'Loading...' : site.client_site_name ?? 'My Site'}
           </h2>
-          <div className="mt-2 flex flex-col gap-1">
+          <div className="mt-1 flex flex-col gap-1">
             <p
-              className={`text-xs font-medium text-ocf-gray-500 transition-all ${
+              className={`text-[10px] font-medium text-ocf-gray-500 transition-all ${
                 !forecastData ? skeleton : ``
               }`}
             >
               Current output:{' '}
               {currentOutput != undefined
-                ? currentOutput.toFixed(2) + ' kW'
+                ? currentOutput.toFixed(1) + ' kW'
                 : 'loading...'}
             </p>
             {site.inverter_capacity_kw !== null && (
               <p
-                className={`text-xs font-medium text-ocf-gray-500 transition-all ${
+                className={`text-[10px] font-medium text-ocf-gray-500 transition-all ${
                   !forecastData ? skeleton : ''
                 }`}
               >
-                Max. capacity: {site.inverter_capacity_kw?.toFixed(2)} kW
+                Max. capacity: {site.inverter_capacity_kw?.toFixed(1)} kW
               </p>
             )}
             <p
-              className={`text-xs font-medium text-ocf-gray-500 transition-all ${
+              className={`text-[10px] font-medium text-ocf-gray-500 transition-all ${
                 !forecastData ? skeleton : ``
               }`}
             >
               Current yield:{' '}
               {site.inverter_capacity_kw && currentOutput != undefined
-                ? (currentOutput / site.inverter_capacity_kw).toFixed(2) + '%'
+                ? (currentOutput / site.inverter_capacity_kw).toFixed(1) + '%'
                 : 'loading...'}
             </p>
           </div>
@@ -79,8 +79,13 @@ const SiteCard: FC<SiteCardProps> = ({ site, isEditMode }) => {
           {!forecastData || !noError ? (
             <div className="h-[100px]"></div>
           ) : (
-            <div className="relative -left-7">
-              <SiteGraph sites={[site]} hidden={isEditMode} />
+            <div className="relative -left-7 top-2">
+              <SiteGraph
+                height={80}
+                sites={[site]}
+                hidden={isEditMode}
+                period={5}
+              />
             </div>
           )}
         </div>

--- a/lib/components/dashboard-modules/NumberDisplay.tsx
+++ b/lib/components/dashboard-modules/NumberDisplay.tsx
@@ -10,19 +10,21 @@ interface Props {
 }
 
 const NumberDisplay: FC<Props> = ({ title, value, onClick, isLoading }) => {
-  const isMobile = useIsMobile()
+  const isMobile = useIsMobile();
 
   const renderDisplay = () => (
     <div className="flex h-full w-full flex-1 flex-col justify-center rounded-lg bg-ocf-black-500 p-4 text-center md:text-left">
       <div
-        className={`mb-2 text-xs font-base text-ocf-gray transition-all md:text-lg md:font-medium md:leading-none ${
+        className={`font-base mb-2 text-xs text-ocf-gray transition-all md:text-lg md:font-medium md:leading-none ${
           isLoading ? skeleton : ``
         }`}
       >
         {title}
       </div>
       <div
-        className={`${isMobile ? 'text-xl' : 'text-2xl'} font-semibold leading-none text-ocf-yellow transition-all md:leading-none ${
+        className={`${
+          isMobile ? 'text-xl' : 'text-2xl'
+        } font-semibold leading-none text-ocf-yellow transition-all md:leading-none ${
           isLoading ? skeleton : ``
         }`}
       >

--- a/lib/components/dashboard-modules/NumberDisplay.tsx
+++ b/lib/components/dashboard-modules/NumberDisplay.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { skeleton } from '~/lib/skeleton';
+import { useIsMobile } from '~/lib/utils';
 
 interface Props {
   title: string;
@@ -9,17 +10,19 @@ interface Props {
 }
 
 const NumberDisplay: FC<Props> = ({ title, value, onClick, isLoading }) => {
+  const isMobile = useIsMobile()
+
   const renderDisplay = () => (
     <div className="flex h-full w-full flex-1 flex-col justify-center rounded-lg bg-ocf-black-500 p-4 text-center md:text-left">
       <div
-        className={`mb-2 text-xs font-semibold text-ocf-gray transition-all md:text-lg md:font-medium md:leading-none ${
+        className={`mb-2 text-xs font-base text-ocf-gray transition-all md:text-lg md:font-medium md:leading-none ${
           isLoading ? skeleton : ``
         }`}
       >
         {title}
       </div>
       <div
-        className={`text-2xl font-semibold leading-none text-ocf-yellow transition-all md:leading-none ${
+        className={`${isMobile ? 'text-xl' : 'text-2xl'} font-semibold leading-none text-ocf-yellow transition-all md:leading-none ${
           isLoading ? skeleton : ``
         }`}
       >

--- a/lib/components/dashboard-modules/NumberDisplay.tsx
+++ b/lib/components/dashboard-modules/NumberDisplay.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import { skeleton } from '~/lib/skeleton';
-import { useIsMobile } from '~/lib/utils';
 
 interface Props {
   title: string;
@@ -10,8 +9,6 @@ interface Props {
 }
 
 const NumberDisplay: FC<Props> = ({ title, value, onClick, isLoading }) => {
-  const isMobile = useIsMobile();
-
   const renderDisplay = () => (
     <div className="flex h-full w-full flex-1 flex-col justify-center rounded-lg bg-ocf-black-500 p-4 text-center md:text-left">
       <div
@@ -22,9 +19,7 @@ const NumberDisplay: FC<Props> = ({ title, value, onClick, isLoading }) => {
         {title}
       </div>
       <div
-        className={`${
-          isMobile ? 'text-xl' : 'text-2xl'
-        } font-semibold leading-none text-ocf-yellow transition-all md:leading-none ${
+        className={`text-xl font-semibold leading-none text-ocf-yellow transition-all md:text-2xl md:leading-none ${
           isLoading ? skeleton : ``
         }`}
       >

--- a/lib/components/graphs/Graph.tsx
+++ b/lib/components/graphs/Graph.tsx
@@ -196,10 +196,12 @@ const Graph: FC<GraphProps> = ({ sites }) => {
             </div>
             <div
               className={overrideTailwindClasses(
-                `flex flex-wrap justify-end gap-1 ${!isSmallMobile && 'text-xs'} sm:gap-3 ${
-                  isSmallMobile && 'text-[10px]'
-                } ${isExtraSmallMobile && 'text-[8px]'} md:text-sm`
-              ,)}
+                `flex flex-wrap justify-end gap-1 ${
+                  !isSmallMobile && 'text-xs'
+                } sm:gap-3 ${isSmallMobile && 'text-[10px]'} ${
+                  isExtraSmallMobile && 'text-[8px]'
+                } md:text-sm`
+              )}
             >
               <div className="flex">
                 <LegendLineGraphIcon className="text-ocf-yellow-500" />

--- a/lib/components/graphs/Graph.tsx
+++ b/lib/components/graphs/Graph.tsx
@@ -78,7 +78,8 @@ const Graph: FC<GraphProps> = ({ sites }) => {
   });
 
   const isMobile = useIsMobile();
-  const isExtraSmallMobile = useMediaQuery('(max-width: 390px)');
+  const isSmallMobile = useMediaQuery('(max-width: 390px)');
+  const isExtraSmallMobile = useMediaQuery('(max-width: 340px)');
 
   const [timeRange, setTimeRange] = useState(48);
 
@@ -195,10 +196,10 @@ const Graph: FC<GraphProps> = ({ sites }) => {
             </div>
             <div
               className={overrideTailwindClasses(
-                `flex flex-wrap justify-end gap-1 text-xs sm:gap-3 ${
-                  isExtraSmallMobile && 'text-[9px]'
-                } md:text-sm`
-              )}
+                `flex flex-wrap justify-end gap-1 ${!isSmallMobile && 'text-xs'} sm:gap-3 ${
+                  isSmallMobile && 'text-[10px]'
+                } ${isExtraSmallMobile && 'text-[8px]'} md:text-sm`
+              ,)}
             >
               <div className="flex">
                 <LegendLineGraphIcon className="text-ocf-yellow-500" />
@@ -207,7 +208,7 @@ const Graph: FC<GraphProps> = ({ sites }) => {
               <div className="flex">
                 <LegendLineGraphIcon className="text-ocf-blue" />
                 <p className="ml-[5px] mt-[2px] text-white">
-                  {isExtraSmallMobile ? 'Clear' : 'Clear Sky'}
+                  {isSmallMobile ? 'Clear' : 'Clear Sky'}
                 </p>
               </div>
               <div className="flex">

--- a/lib/components/graphs/SiteGraph.tsx
+++ b/lib/components/graphs/SiteGraph.tsx
@@ -15,15 +15,6 @@ interface SiteGraphProps {
   color?: string;
 }
 
-/**
- *
- * @param sites an array of sites, which the site graph will aggregate and show
- * @param hidden optional, hides the graph if true
- * @param height optional, height of container, default 100
- * @param period optional, period of centered moving average applied to data for smoothing, default 1, must be odd
- * @color optional
- * @returns corresponding mini graph
- */
 const SiteGraph: FC<SiteGraphProps> = ({
   sites,
   hidden = false,

--- a/lib/components/navigation/DashboardLink.tsx
+++ b/lib/components/navigation/DashboardLink.tsx
@@ -62,6 +62,7 @@ const DashboardLink: React.FC<DashboardLinkProps> = ({
           color={
             isActive ? '#FFD053' /* ocf-yellow */ : '#909090' /*ocf-gray-800*/
           }
+          period={3}
         />
       </div>
     </Link>

--- a/lib/components/navigation/SideBar.tsx
+++ b/lib/components/navigation/SideBar.tsx
@@ -143,7 +143,7 @@ const SideBar: FC<SideBarProps> = ({ open, onClose }) => {
             </div>
           </button>
         )}
-        <div className="mt-10 flex flex-col gap-3">
+        <div className="mt-10 flex flex-col">
           <button onClick={handleEditClick}>
             <div className="flex items-center gap-3 rounded-md px-4 py-2 text-gray-600 transition-all hover:bg-ocf-gray-1000 hover:text-gray-700">
               <div className={isEditMode ? 'text-amber' : 'text-white'}>

--- a/pages/help/[page].tsx
+++ b/pages/help/[page].tsx
@@ -56,7 +56,7 @@ const Help = () => {
           })}
         </div>
       </div>
-      <div className="min-h-screen w-screen max-w-screen-sm bg-ocf-black px-4">
+      <div className="min-h-screen w-screen max-w-screen-sm bg-ocf-black px-6 md:px-4">
         <ReactMarkdown
           components={{
             h1: ({ node, ...props }) => (
@@ -72,7 +72,7 @@ const Help = () => {
               />
             ),
             p: ({ node, ...props }) => (
-              <p className="text-l pb-1.5 text-white" {...props} />
+              <p className="text-sm md:text-base pb-1.5 text-white" {...props} />
             ),
             ul: ({ node, ...props }) => (
               <ul

--- a/pages/help/[page].tsx
+++ b/pages/help/[page].tsx
@@ -72,7 +72,10 @@ const Help = () => {
               />
             ),
             p: ({ node, ...props }) => (
-              <p className="text-sm md:text-base pb-1.5 text-white" {...props} />
+              <p
+                className="pb-1.5 text-sm text-white md:text-base"
+                {...props}
+              />
             ),
             ul: ({ node, ...props }) => (
               <ul

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -15,8 +15,8 @@ const Sites = () => {
 
   return (
     <div className="mb-[var(--bottom-nav-margin)] flex h-full w-full max-w-lg flex-col items-center gap-3 px-5">
-      <div className="mb-4 flex h-12 w-full flex-row items-end">
-        <h1 className="flex-1 text-3xl font-bold text-ocf-gray">My Sites</h1>
+      <div className="flex h-6 w-full flex-row items-center">
+        <h1 className="flex-1 text-xl font-semibold text-ocf-gray">My Sites</h1>
         <button onClick={() => setEditMode(!editMode)}>
           {editMode ? (
             <p className="text-base font-semibold text-amber">Done</p>
@@ -25,6 +25,7 @@ const Sites = () => {
           )}
         </button>
       </div>
+      <hr className="mx-[-100px] h-[1px] w-[500%] mb-4 border-0 bg-ocf-black-500 md:hidden" />
       {sites.map((site) => (
         <SiteCard key={site.site_uuid} site={site} isEditMode={editMode} />
       ))}

--- a/pages/sites.tsx
+++ b/pages/sites.tsx
@@ -1,5 +1,5 @@
 import { PlusCircleIcon } from '@heroicons/react/24/outline';
-import { PencilSquareIcon } from '@heroicons/react/24/solid';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 import { useState } from 'react';
 import SiteCard from '~/lib/components/SiteCard';
@@ -15,7 +15,7 @@ const Sites = () => {
 
   return (
     <div className="mb-[var(--bottom-nav-margin)] flex h-full w-full max-w-lg flex-col items-center gap-3 px-5">
-      <div className="flex h-6 w-full flex-row items-center">
+      <div className="flex h-6 w-full flex-row items-start">
         <h1 className="flex-1 text-xl font-semibold text-ocf-gray">My Sites</h1>
         <button onClick={() => setEditMode(!editMode)}>
           {editMode ? (
@@ -25,7 +25,7 @@ const Sites = () => {
           )}
         </button>
       </div>
-      <hr className="mx-[-100px] h-[1px] w-[500%] mb-4 border-0 bg-ocf-black-500 md:hidden" />
+      <hr className="mx-[-100px] mb-4 h-[1px] w-[500%] border-0 bg-ocf-black-500 md:hidden" />
       {sites.map((site) => (
         <SiteCard key={site.site_uuid} site={site} isEditMode={editMode} />
       ))}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
     screens: {
       ...defaultTheme.screens,
       short: { raw: '(max-height: 800px)' },
+      xm: { max: '400px' },
     },
     container: {
       center: true,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,6 +64,15 @@ module.exports = {
           'Weather-Icons Weather-Icons',
           'Graph Graph',
         ],
+        'dashboard-mobile-xs': [
+          'Heading1 Heading1',
+          'Sunny Recommendation',
+          'Site-Graph   Site-Graph',
+          'Heading2 Heading2',
+          'Current-Output Current-Output',
+          'Weather-Icons Weather-Icons',
+          'Graph Graph',
+        ],
       },
       gridTemplateColumns: {
         'desktop-columns': '1fr 1fr 1fr',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,7 @@ module.exports = {
     screens: {
       ...defaultTheme.screens,
       short: { raw: '(max-height: 800px)' },
-      xm: { max: '400px' },
+      xs: { max: '400px' },
     },
     container: {
       center: true,


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready
<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Closes #302, closes #295 

Also fixes apparent bug in mobile sites page, where loading was showing even if forecast data was available. Changes various text sizes throughout the app to be mobile responsive and consistent with the Figma. Adds option to site graph to apply smoothing through moving average, applies smoothing on site pages and desktop sidebar. 

<!--
A few sentences describing the overall goals of the pull request's commits.
-->
<img width="1416" alt="image" src="https://github.com/openclimatefix/pv-sites-mobile/assets/62641231/d2d3da6a-9226-493e-9e79-214b86cc6b9a">
<img width="355" alt="Screenshot 2023-05-19 at 9 51 09 AM" src="https://github.com/openclimatefix/pv-sites-mobile/assets/62641231/86cd753c-0a07-4dc7-9874-00c82b4f9be2">


<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
